### PR TITLE
c-with-prep: comment out patches in the specfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BRANCH ?= c8s
 DIR ?= git.centos.org
 IMAGE_NAME := dist2src
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
+CONTAINER_CMD ?= /bin/bash
 
 usage:
 	@echo "Run 'make convert' to run the convert or 'make clean' to clean up things."
@@ -34,4 +35,12 @@ build:
 	$(CONTAINER_ENGINE) build -t $(IMAGE_NAME) .
 
 run:
-	$(CONTAINER_ENGINE) run -ti -v $(CURDIR)/dist2src:/usr/local/lib/python3.6/site-packages/dist2src:Z --entrypoint= $(OPTS) $(IMAGE_NAME) /bin/bash
+	$(CONTAINER_ENGINE) run \
+		-ti --rm \
+		-v $(CURDIR)/dist2src:/usr/local/lib/python3.6/site-packages/dist2src:Z \
+		-v $(CURDIR)/packitpatch:/usr/bin/packitpatch \
+		-v $(CURDIR)/macros.packit:/usr/lib/rpm/macros.d/macros.packit \
+		--entrypoint= \
+		-u $(shell id -u) \
+		$(OPTS) \
+		$(IMAGE_NAME) $(CONTAINER_CMD)

--- a/README.md
+++ b/README.md
@@ -175,3 +175,14 @@ sub-directory and the resulting source-git repo is going to be stored in
 [how to source-git?]: https://packit.dev/docs/source-git/how-to-source-git/
 [`get_sources.sh`]: https://wiki.centos.org/Sources#get_sources.sh_script
 [rebase-helper's `get_applied_patches()`]: https://github.com/rebase-helper/rebase-helper/blob/e98f4f6b14e2ca2e8cbb8a8fbeb6935e5d0cf289/rebasehelper/specfile.py#L351
+
+## Tests
+
+You can find functional tests which convert real dist-git packages. They
+require setup in your environment:
+
+- Build an image with the dist2src inside (`make build`) -- you can override
+  container engine of your choice with env var `CONTAINER_ENGINE` (hint, root
+  podman has better performance than rootless, so `CONTAINER_ENGINE="sudo podman"`).
+- Have mock installed and set up -- last step of the testing is to build the
+  generated SRPM from a source-git repo using `mock --rebuild -r centos-stream-x86_64`).

--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -213,6 +213,7 @@ def run_prep(path):
             raise
 
         repo = git.Repo(cwd)
+        # let's revert the spec change in dist-git
         repo.git.checkout("--", "SPECS/")
 
         hook_cmd = get_hook(Path(path), AFTER_PREP_HOOK)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def convert_repo(package_name, dist_git_path, sg_path):
+    subprocess.check_call(
+        [
+            "git",
+            "clone",
+            "-b",
+            "c8s",
+            f"https://git.centos.org/rpms/{package_name}.git",
+            dist_git_path,
+        ]
+    )
+    make_env = os.environ.copy()
+    make_cmd = ["make", "run"]
+    container_sg_p = f"/s/{package_name}"
+    container_dg_p = f"/d/{package_name}"
+    make_env.update(
+        {
+            "OPTS": (
+                f"-v {dist_git_path}:{container_dg_p}:rw "
+                f"-v {sg_path}:{container_sg_p}:rw --workdir /"
+            ),
+            "CONTAINER_CMD": (
+                f"dist2src -vv convert-with-prep "
+                f"{container_dg_p}:c8s {container_sg_p}:c8s"
+            ),
+        }
+    )
+
+    subprocess.check_call(make_cmd, env=make_env)
+
+
+@pytest.mark.parametrize(
+    "package_name",
+    (
+        "rpm",
+        "drpm",
+        "HdrHistogram_c"
+        # "kernel"  one day
+    ),
+)
+def test_conversions(tmp_path: Path, package_name):
+    dist_git_path = tmp_path / "d" / package_name
+    sg_path = tmp_path / "s" / package_name
+    dist_git_path.mkdir(parents=True)
+    sg_path.mkdir(parents=True)
+    convert_repo(package_name, dist_git_path, sg_path)
+    subprocess.check_call(["packit", "srpm"], cwd=sg_path)
+    srpm_path = next(sg_path.glob("*.src.rpm"))
+    assert srpm_path.exists()
+    subprocess.check_call(
+        ["mock", "--rebuild", "-r", "centos-stream-x86_64", srpm_path]
+    )


### PR DESCRIPTION
so that packit can create them and can be used during build

this is a short-term solution, we aim to go towards patch metadata

TODO:
* [x] needs to point to the base commit (e.g. `rpm-4.14.2 base`)

Long term todo:
* we need to apply patches with the patch program b/c git-apply and patch use different algorithm (try c8s of rpm)