### PR TITLE
run-prep: override __scm_apply_patch

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,8 @@ RUN $package_manager -y install \
     bison \
     flex \
     make \
-    && $package_manager -y clean all
+    && $package_manager -y clean all \
+    && pip3 install ipdb
 
 
 RUN git config --system user.name "Packit" && git config --system user.email "packit"

--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,8 @@ RUN $package_manager -y install \
     bison \
     flex \
     make \
+    autoconf \
+    automake \
     && $package_manager -y clean all \
     && pip3 install ipdb
 

--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -16,10 +16,9 @@ import click
 import git
 import sh
 import timeout_decorator
+from packit.config.package_config import get_local_specfile_path
 from rebasehelper.specfile import SpecFile
 from yaml import dump
-
-from packit.config.package_config import get_local_specfile_path
 
 # packitos currently requires python>=3.7, but CentOS 8 has python==3.6 by default.
 # Remove this once a version of packitos>0.13.1 is released.
@@ -126,7 +125,7 @@ def log_call(func):
         args_string = ", ".join([repr(a) for a in args])
         kwargs_string = ", ".join([f"{k}={v!r}" for k, v in kwargs.items()])
         sep = ", " if args_string and kwargs_string else ""
-        logger.debug(f"{func.__name__}({args_string}{sep}{kwargs_string})")
+        logger.info(f"{func.__name__}({args_string}{sep}{kwargs_string})")
         ret = func(*args, **kwargs)
         return ret
 
@@ -223,10 +222,13 @@ def run_prep(ctx, path):
         logger.debug(f"Running rpmbuild in {cwd}")
         specfile_path = Path(f"SPECS/{cwd.name}.spec")
 
+        verbosity_level = ""
+        if ctx.obj[VERBOSE_KEY]:  # -vv can be super-duper verbose
+            verbosity_level = "-" + "v" * ctx.obj[VERBOSE_KEY]
         try:
             running_cmd = rpmbuild(
                 "--nodeps",
-                "-vv" if ctx.obj[VERBOSE_KEY] else "",
+                verbosity_level,
                 "--define",
                 f"_topdir {cwd}",
                 "-bp",

--- a/macros.packit
+++ b/macros.packit
@@ -1,9 +1,26 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-#
-# This is almost the same as %autosetup: runs %setup then %__scm_setup_* and
-# defines __patch as a custom script.
-%gitsetup(a:b:cDn:Tq)\
-%setup %{-a} %{-b} %{-c} %{-D} %{-n} %{-T} %{-q}\
-%global __patch /usr/bin/packitpatch\
-%{expand:%__scm_setup_%{__scm} %{!-q:-v}}
+
+# we want both: here and in packitpatch
+# if there are no patches, packitpatch never gets invoked and this will b/c of autosetup
+%__scm_setup_patch(q)\
+%{__git} init\
+%{__git} add .\
+%{__git} commit --allow-empty -a -m "%{NAME}-%{VERSION} base"
+
+# %{1} = absolute path to the patch
+# %{2} = patch ID
+%__scm_apply_patch(qp:m:)\
+/usr/bin/packitpatch %{1} %{2} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags}
+
+%__scm_setup_git(q)\
+%{__git} init %{-q}\
+%{__git} add .\
+%{__git} commit %{-q} --allow-empty -a -m "%{NAME}-%{VERSION} base"
+
+%__scm_apply_git_am(qp:m:)\
+%{__git} am %{-q} %{-p:-p%{-p*}}\
+patch_name=`basename %{1}`\
+commit_msg=`%{__git} log --format=%B -n1`\
+metadata_commit_msg=`printf "patch_name: $patch_name\\npresent_in_specfile: true\\nlocation_in_specfile: %{2}\\nsquash_commits: true"`\
+%{__git} commit --amend -m "$commit_msg" -m "$metadata_commit_msg"

--- a/packitpatch
+++ b/packitpatch
@@ -3,27 +3,33 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+# do set -x for development/debugging
 set -eu
 
-# This patchnum is not the same as the patchnum in the spec file, as we just
-# sequentially count the patches here.
-PATCHNUM=1
-[ -f /tmp/patchnum ] && PATCHNUM=$(cat /tmp/patchnum)
-
-patch_file=$(mktemp)
-cat - > "$patch_file"
-
-set +e
-# Ignore all the flags unknown to git am
-git_am_options=$(getopt -o qp: -- $@)
-cat "$patch_file" | /usr/bin/git am $git_am_options
-git_am_exit_code=$?
-set -e
-
-if [ $git_am_exit_code -ne 0 ]; then
-    cat "$patch_file" | /usr/bin/patch $@
-    git add .
-    git commit -m "Apply patch #$PATCHNUM"
+# we cannot override %__scm_setup_patch b/c it is called from %autosetup
+# and some specs have %setup + %autopatch, so we need to make sure
+# the git repo exists here
+if [ ! -d .git ]; then
+  git init
+  git add .
+  # that PWD magic prints the name of the PWD, which usually is NAME-VERSION
+  git commit --allow-empty -a -m "${PWD##*/} base"
 fi
 
-echo $((PATCHNUM+1)) > /tmp/patchnum
+patch_path=$1
+patch_name=$(basename $1)
+patch_id=$2
+
+# we process first and second arg above, the rest is for patch
+cat - | /usr/bin/patch ${@:3}
+
+commit_message=$(cat << EOF
+Apply patch ${patch_name}
+
+patch_name: ${patch_name}
+location_in_specfile: ${patch_id}
+present_in_specfile: true
+EOF
+)
+git add .
+git commit -m "$commit_message"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -31,7 +31,7 @@ def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
                 f"-v {sg_path}:{container_sg_p}:rw --workdir /"
             ),
             "CONTAINER_CMD": (
-                f"dist2src -vv convert-with-prep "
+                f"dist2src -v convert-with-prep "
                 f"{container_dg_p}:{branch} {container_sg_p}:{branch}"
             ),
         }

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,13 +9,13 @@ from pathlib import Path
 import pytest
 
 
-def convert_repo(package_name, dist_git_path, sg_path):
+def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
     subprocess.check_call(
         [
             "git",
             "clone",
             "-b",
-            "c8s",
+            branch,
             f"https://git.centos.org/rpms/{package_name}.git",
             dist_git_path,
         ]
@@ -32,7 +32,7 @@ def convert_repo(package_name, dist_git_path, sg_path):
             ),
             "CONTAINER_CMD": (
                 f"dist2src -vv convert-with-prep "
-                f"{container_dg_p}:c8s {container_sg_p}:c8s"
+                f"{container_dg_p}:{branch} {container_sg_p}:{branch}"
             ),
         }
     )
@@ -41,23 +41,44 @@ def convert_repo(package_name, dist_git_path, sg_path):
 
 
 @pytest.mark.parametrize(
-    "package_name",
+    "package_name,branch",
     (
-        "rpm",
-        "drpm",
-        "HdrHistogram_c"
-        # "kernel"  one day
+        ("rpm", "c8s"),  # %autosetup and lots of patches
+        ("drpm", "c8s"),  # easy
+        ("HdrHistogram_c", "c8s"),  # eaaaaasy
+        ("units", "c8"),  # autosetup + files created during %prep
+        # %autosetup -S git_am + needs https://koji.mbox.centos.org/koji/taginfo?tagID=342
+        # "pacemaker",
+        # ("systemd", "c8s"),  # -S git_am
+        # ("kernel", "c8s"),  # !!!
+        (
+            "qemu-kvm",
+            "c8s-stream-rhel",
+        ),  # %setup -q -n qemu-%{version} + %autopatch -p1
+        (
+            "libvirt",
+            "c8s-stream-rhel",
+        ),  # %autosetup -S git_am -N + weirdness + %autopatch
     ),
 )
-def test_conversions(tmp_path: Path, package_name):
+def test_conversions(tmp_path: Path, package_name, branch):
     dist_git_path = tmp_path / "d" / package_name
     sg_path = tmp_path / "s" / package_name
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
-    convert_repo(package_name, dist_git_path, sg_path)
-    subprocess.check_call(["packit", "srpm"], cwd=sg_path)
+    convert_repo(package_name, dist_git_path, sg_path, branch=branch)
+    subprocess.check_call(["packit", "--debug", "srpm"], cwd=sg_path)
     srpm_path = next(sg_path.glob("*.src.rpm"))
     assert srpm_path.exists()
+    # we don't care about the build itself, mainly that patches are applied correctly, hence -bp
+    return
     subprocess.check_call(
-        ["mock", "--rebuild", "-r", "centos-stream-x86_64", srpm_path]
+        [
+            "mock",
+            "--rpmbuild-opts=-bp",
+            "--rebuild",
+            "-r",
+            "centos-stream-x86_64",
+            srpm_path,
+        ]
     )


### PR DESCRIPTION
```
This is the easier way of doing what we need. We need people to apply
the way they want and instead let us handle applying by patch and git.

We do this, initially, just by replacing __scm_apply_patch with our
implementation which is the same except:
1. it handles patch name and ID for sake of patch metadata
2. uses our packitpatch shell script

packitpatch is also simpler now
- it creates a git repo if .git is not present
- accepts patch name and ID (commit message, patch metadata)
```

TODO:
* [x] make sure all tests are passing