### PR TITLE
make run-prep work when not verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,6 @@ tests/test_convert.py::test_conversions[rpm-c8s] PASSED                         
 
 ================================== 1 passed in 21.39 seconds ==================================
 ```
+
+**The test suite works only with root podman, so please make sure to run it
+with `CONTAINER_ENGINE='sudo podman'`.** Or feel free to fix it.

--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -222,18 +222,18 @@ def run_prep(ctx, path):
         logger.debug(f"Running rpmbuild in {cwd}")
         specfile_path = Path(f"SPECS/{cwd.name}.spec")
 
-        verbosity_level = ""
+        rpmbuild_args = [
+            "--nodeps",
+            "--define",
+            f"_topdir {cwd}",
+            "-bp",
+        ]
         if ctx.obj[VERBOSE_KEY]:  # -vv can be super-duper verbose
-            verbosity_level = "-" + "v" * ctx.obj[VERBOSE_KEY]
+            rpmbuild_args.append("-" + "v" * ctx.obj[VERBOSE_KEY])
+        rpmbuild_args.append(specfile_path)
+
         try:
-            running_cmd = rpmbuild(
-                "--nodeps",
-                verbosity_level,
-                "--define",
-                f"_topdir {cwd}",
-                "-bp",
-                specfile_path,
-            )
+            running_cmd = rpmbuild(*rpmbuild_args)
         except sh.ErrorReturnCode as e:
             for line in e.stderr.splitlines():
                 logger.debug(str(line))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -67,6 +67,7 @@ def test_conversions(tmp_path: Path, package_name, branch):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
     convert_repo(package_name, dist_git_path, sg_path, branch=branch)
+    # if rootless, we fail here to fetch the archive b/c the container user created the dir
     subprocess.check_call(["packit", "--debug", "srpm"], cwd=sg_path)
     srpm_path = next(sg_path.glob("*.src.rpm"))
     assert srpm_path.exists()


### PR DESCRIPTION
\+ testing: document that rootless is not working