### PR TITLE
support "%autosetup -S git": apply patch metadata

### DIFF
--- a/macros.packit
+++ b/macros.packit
@@ -18,9 +18,16 @@
 %{__git} add .\
 %{__git} commit %{-q} --allow-empty -a -m "%{NAME}-%{VERSION} base"
 
+# commit_msg contains commit message of the last commit
 %__scm_apply_git_am(qp:m:)\
 %{__git} am %{-q} %{-p:-p%{-p*}}\
 patch_name=`basename %{1}`\
 commit_msg=`%{__git} log --format=%B -n1`\
 metadata_commit_msg=`printf "patch_name: $patch_name\\npresent_in_specfile: true\\nlocation_in_specfile: %{2}\\nsquash_commits: true"`\
 %{__git} commit --amend -m "$commit_msg" -m "$metadata_commit_msg"
+
+%__scm_apply_git(qp:m:)\
+%{__git} apply --index %{-p:-p%{-p*}} -\
+patch_name=`basename %{1}`\
+metadata_commit_msg=`printf "patch_name: $patch_name\\npresent_in_specfile: true\\nlocation_in_specfile: %{2}"`\
+%{__git} commit %{-q} -m %{-m*} -m "$metadata_commit_msg" --author "%{__scm_author}"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -59,6 +59,8 @@ def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
             "libvirt",
             "c8s-stream-rhel",
         ),  # %autosetup -S git_am -N + weirdness + %autopatch
+        # ( "libreport", "c8s")  # -S git, they redefine "__scm_apply_git"
+        ("vhostmd", "c8s"),  # -S git, eazy
     ),
 )
 def test_conversions(tmp_path: Path, package_name, branch):


### PR DESCRIPTION
Fixes #34

redefine __scm_apply_git so that we would apply patch metadata so that
packit can create SRPM correctly and doesn't need to "guess" patches