### PR TITLE
re-add support for %setup+%patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,24 +63,21 @@ Simply put:
 
 ## Using `rpmbuild -bp` to generate source-git repositories
 
-`convert-with-prep` is a slightly different approach than the original
-one as instead of parsing the SPEC-file to apply the patches it relies on
-`rpmbuild -bp` to run the `%prep` stage from the spec file which results
-in a directory containing the unpacked sources (under `./BUILD/*`).
+The core way of the conversion process is running `rpmbuild -bp` to execute the
+`%prep` stage from the spec file which results in a directory containing the
+unpacked sources (under `<dist-git>/BUILD/*`).
 
 With the following RPM-macro tweaks this directory can be turned into a Git
 repository from where the script can pull the history resulting from the
 conversion:
 
-- `__scm` is always `git`—this way all `%autosetup` macros will result in a
-  Git repository, even the ones which are missing the `-S git[_am]` flag.
+- We override all `scm_setup` and `scm_apply` macros so they create a git repo
+  from the archive and commit every patch applied.
 - SPEC-files which use `%setup` are modified before the conversion to use
-  `%gitsetup` instead. `%gitsetup` is a [custom macro](macros.packit), which
-  makes the `%prep` section to be executed similar to how `%autosetup` would
-  do: initializes a Git repository and applies the patches [as Git
-  commits](packitpatch). Currently it will also create a "various changes"
-  commit to capture any modification of the exploded sources which happens
-  additionally to applying the patches.
+  `%autosetup -N` instead. This means the tool initializes a Git repository and
+  applies the patches [as Git commits](packitpatch). Currently it will also
+  create a "Changes after running %prep" commit to capture any modification of
+  the exploded sources which happens additionally to applying the patches.
 
 ## Converting in a CentOS environment
 

--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -182,12 +182,12 @@ def add_packit_config(ctx, dest: str):
     d2s.add_packit_config()
 
 
-@cli.command("convert-with-prep")
+@cli.command("convert")
 @click.argument("origin", type=click.STRING)
 @click.argument("dest", type=click.STRING)
 @log_call
 @click.pass_context
-def convert_with_prep(ctx, origin: str, dest: str):
+def convert(ctx, origin: str, dest: str):
     """Convert a dist-git repository into a source-git repository, using
     'rpmbuild' and executing the "%prep" stage from the spec file.
 

--- a/macros.packit
+++ b/macros.packit
@@ -13,6 +13,8 @@
 %__scm_apply_patch(qp:m:)\
 /usr/bin/packitpatch %{1} %{2} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags}
 
+%__patch /usr/bin/packitpatch %{1} %{2} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags}
+
 %__scm_setup_git(q)\
 %{__git} init %{-q}\
 %{__git} add .\

--- a/packitpatch
+++ b/packitpatch
@@ -16,8 +16,14 @@ if [ ! -d .git ]; then
   git commit --allow-empty -a -m "${PWD##*/} base"
 fi
 
-patch_path=$1
-patch_name=$(basename $1)
+if [ "$1" == "%{1}" ]; then
+  # rpm pipes the patch here
+  # also, Michal Domonkos is a genius
+  patch_path=$(readlink -f /dev/stdin)
+else
+  patch_path=$1
+fi
+patch_name=$(basename $patch_path)
 patch_id=$2
 
 # we process first and second arg above, the rest is for patch
@@ -27,9 +33,12 @@ commit_message=$(cat << EOF
 Apply patch ${patch_name}
 
 patch_name: ${patch_name}
-location_in_specfile: ${patch_id}
 present_in_specfile: true
 EOF
 )
+if [ "$patch_id" != "%{2}" ]; then
+  # concat 2 strings and separate them with \n - a nightmare to do in bash
+  printf -v commit_message "${commit_message}\nlocation_in_specfile: ${patch_id}"
+fi
 git add .
 git commit -m "$commit_message"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -29,7 +29,7 @@ def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
                 f"-v {sg_path}:{container_sg_p}:rw,Z --workdir /"
             ),
             "CONTAINER_CMD": (
-                f"dist2src -v convert-with-prep "
+                f"dist2src -v convert "
                 f"{container_dg_p}:{branch} {container_sg_p}:{branch}"
             ),
         }

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -29,7 +29,7 @@ def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
                 f"-v {sg_path}:{container_sg_p}:rw,Z --workdir /"
             ),
             "CONTAINER_CMD": (
-                f"dist2src -v convert "
+                f"dist2src -vv convert "
                 f"{container_dg_p}:{branch} {container_sg_p}:{branch}"
             ),
         }
@@ -58,7 +58,10 @@ def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
             "c8s-stream-rhel",
         ),  # %autosetup -S git_am -N + weirdness + %autopatch
         # ( "libreport", "c8s")  # -S git, they redefine "__scm_apply_git"
+        ("socat", "c8s"),  # %setup + %patch
         ("vhostmd", "c8s"),  # -S git, eazy
+        ("autogen", "c8s"),
+        ("autofs", "c8s"),
     ),
 )
 def test_conversions(tmp_path: Path, package_name, branch):


### PR DESCRIPTION
We need to explicitly support the %setup + %patch combo because these
two macros can't be replaced via the traditional macro system in
/usr/lib/rpm/ since rpm parses them via C code in:

https://github.com/rpm-software-management/rpm/pull/1350

This patch tries to detect the usage of %setup - if any of the
%auto{setup,patch} are used, we're good since those use the
%__scm_{setup/apply} which we override to make sure git repos are
created. Otherwise d2s replaces %setup with '%autosetup -N' (-N to let
%patch do the job). With that change we'll be sure that git repo is
created during %prep. We then replace %__patch with packitpatch to apply
the patches.

The last missing piece was patch metadata - rpm does not pass the patch
name to %__patch. Luckily, Michal Domonkos is so fabulous - we can
`readlink -f /dev/stdin` which points to the actual patch (rpm does `cat
$patch | %__patch`).

🍻 🥂 🎉 🥳

Fixes #37
