### PR TITLE
[.zuul.yaml] remove options set in base job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,10 +13,4 @@
     parent: base
     attempts: 1
     description: Run tests
-    extra-vars:
-      ansible_python_interpreter: /usr/bin/python3
-    nodeset:
-      nodes:
-        - name: test-node
-          label: cloud-fedora-32
     run: zuul-tests.yaml


### PR DESCRIPTION
https://github.com/packit/packit-service-zuul/blob/master/zuul.d/jobs.yaml#L20

`ansible_python_interpreter` is not set in the base job, because it doesn't seem to be needed.