### PR TITLE
Test localhost

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,6 +4,7 @@
       jobs:
         - pre-commit
         - dist2src-tests
+        - dist2src-tests-inside-container
     gate:
       jobs:
         - pre-commit
@@ -14,3 +15,11 @@
     attempts: 1
     description: Run tests
     run: zuul-tests.yaml
+
+- job:
+    # job names are global, this should be unique
+    name: dist2src-tests-inside-container
+    parent: base
+    attempts: 1
+    description: Run tests
+    run: zuul-tests-inside-container.yaml

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ RUN $package_manager -y install \
     autoconf \
     automake \
     && $package_manager -y clean all \
-    && pip3 install ipdb
+    && pip3 install ipdb pytest
 
 
 RUN git config --system user.name "Packit" && git config --system user.email "packit"

--- a/tests_localhost/test_convert.py
+++ b/tests_localhost/test_convert.py
@@ -1,0 +1,95 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+from pathlib import Path
+from click.testing import CliRunner
+
+import pytest
+
+from dist2src.cli import cli
+from packit.cli.packit_base import packit_base
+
+
+def run_dist2src(*args, **kwargs):
+    cli_runner = CliRunner()
+    cli_runner.invoke(cli, *args, catch_exceptions=False, **kwargs)
+
+
+def run_packit(*args, **kwargs):
+    cli_runner = CliRunner()
+    cli_runner.invoke(packit_base, *args, catch_exceptions=False, **kwargs)
+
+
+def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
+    subprocess.check_call(
+        [
+            "git",
+            "clone",
+            "-b",
+            branch,
+            f"https://git.centos.org/rpms/{package_name}.git",
+            dist_git_path,
+        ]
+    )
+    run_dist2src(
+        ["-vvv", "convert", f"{dist_git_path}:{branch}", f"{sg_path}:{branch}"]
+    )
+
+
+@pytest.mark.parametrize(
+    "package_name,branch",
+    (
+        ("rpm", "c8s"),  # %autosetup and lots of patches
+        ("drpm", "c8s"),  # easy
+        ("HdrHistogram_c", "c8s"),  # eaaaaasy
+        ("units", "c8"),  # autosetup + files created during %prep
+        # %autosetup -S git_am + needs https://koji.mbox.centos.org/koji/taginfo?tagID=342
+        # "pacemaker",
+        # ("systemd", "c8s"),  # -S git_am
+        # ("kernel", "c8s"),  # !!!
+        (
+            "qemu-kvm",
+            "c8s-stream-rhel",
+        ),  # %setup -q -n qemu-%{version} + %autopatch -p1
+        (
+            "libvirt",
+            "c8s-stream-rhel",
+        ),  # %autosetup -S git_am -N + weirdness + %autopatch
+        # ( "libreport", "c8s")  # -S git, they redefine "__scm_apply_git"
+        ("socat", "c8s"),  # %setup + %patch
+        ("vhostmd", "c8s"),  # -S git, eazy
+        ("autogen", "c8s"),
+        ("autofs", "c8s"),
+    ),
+)
+def test_conversions(tmp_path: Path, package_name, branch):
+    dist_git_path = tmp_path / "d" / package_name
+    sg_path = tmp_path / "s" / package_name
+    dist_git_path.mkdir(parents=True)
+    sg_path.mkdir(parents=True)
+    convert_repo(package_name, dist_git_path, sg_path, branch=branch)
+
+    run_packit(
+        [
+            "--debug",
+            "srpm",
+            "--output",
+            str(sg_path / f"{package_name}.src.rpm"),
+            str(sg_path),
+        ]
+    )
+    srpm_path = next(sg_path.glob("*.src.rpm"))
+    assert srpm_path.exists()
+    # TODO: implement `packit prep` and run it here
+    return
+    subprocess.check_call(
+        [
+            "mock",
+            "--rpmbuild-opts=-bp",
+            "--rebuild",
+            "-r",
+            "centos-stream-x86_64",
+            srpm_path,
+        ]
+    )

--- a/zuul-tests-inside-container.yaml
+++ b/zuul-tests-inside-container.yaml
@@ -1,0 +1,29 @@
+---
+- name: Build test image & run tests in container
+  hosts: all
+  tasks:
+    - name: Install git and podman
+      dnf:
+        name:
+          - git-core
+          - podman
+      become: true
+    - name: Set project_dir variable when running this locally
+      set_fact:
+        project_dir: "{{ playbook_dir }}"
+    - name: Set project_dir variable when running in zuul
+      set_fact:
+        project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+      when: zuul is defined
+    - name: Build dist2src container image
+      command: make build
+      args:
+        chdir: "{{ project_dir }}"
+      become: true
+    - name: Run tests
+      command: make check-in-container
+      args:
+        chdir: "{{ project_dir }}"
+      environment:
+        COLOR: "no"
+      become: true


### PR DESCRIPTION
- Add testsuite that runs locally.
- Add `make check-in-container` to run the test-suite in the container.
- Run the `make check-in-container` in zuul.

Why?
- You can run tests where you want.
- You don't need to have all dependencies (including packit's) locally.
- Time speed-up. We don't need to run container for each test-case.

We can switch to this approach completelly if we want.