### PR TITLE
Add dependencies needed by some packages and fix error msg

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,9 +15,11 @@ RUN $package_manager -y install \
     make \
     autoconf \
     automake \
+    gettext-devel \
+    sscg \
+    libtool \
     && $package_manager -y clean all \
     && pip3 install ipdb pytest
-
 
 RUN git config --system user.name "Packit" && git config --system user.email "packit"
 COPY .git /src/.git

--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -59,9 +59,9 @@ def get_hook(package_name: str, hook_name: str) -> Optional[str]:
 def get_build_dir(path: Path):
     build_dirs = [d for d in (path / "BUILD").iterdir() if d.is_dir()]
     if len(build_dirs) > 1:
-        raise RuntimeError(f"More than one directory found in {path}")
+        raise RuntimeError(f"More than one directory found in {path / 'BUILD'}")
     if len(build_dirs) < 1:
-        raise RuntimeError(f"No subdirectory found in {path}")
+        raise RuntimeError(f"No subdirectory found in {path / 'BUILD'}")
     return build_dirs[0]
 
 


### PR DESCRIPTION
`gettext-devel` - first added for coreutils
`sscg` - first added fo cyrus-imapd
`libtool` - first added for fribidi
    
Other packages that need one of the three:
     - firewalld, gd, libkcapi, libglvnd, iprutils, liblouis, libmspack, libteam, libtiff, libva, libvncserver, pam, perftest, plymouth, pulseaudio, python-pycurl