### PR TITLE
cherry_pick_base: do empty commit for no archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ run:
 check:
 	pytest-3 --color=$(COLOR) --showlocals -vv $(TEST_TARGET)
 
+# if you want to inspect repos which are created during a test run, do `-v /tmp:/tmp` and navigate to /tmp/pytest*/...
+# sadly this doesn't work in CI (SELinux?)
 check-in-container:
 	$(CONTAINER_ENGINE) run \
 		-ti --rm \

--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,6 @@ check-in-container:
 		-v $(CURDIR)/tests:/tests:Z \
 		--entrypoint= \
 		-u $(shell id -u) \
+		-w / \
 		$(OPTS) \
-		$(IMAGE_NAME) pytest --color=$(COLOR) --showlocals -vv /$(TEST_TARGET)
+		$(IMAGE_NAME) pytest --color=$(COLOR) --showlocals -vv $(TEST_TARGET)

--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Dict, Any, Union
 
 import git
 import sh
+from git import GitCommandError
 from packit.specfile import Specfile
 from yaml import dump
 
@@ -159,7 +160,13 @@ class GitRepo:
             if theirs
             else {}
         )
-        self.repo.git.cherry_pick(f"{from_branch}~{num_commits - 1}", **git_options)
+        try:
+            self.repo.git.cherry_pick(f"{from_branch}~{num_commits - 1}", **git_options)
+        except GitCommandError as ex:
+            if "nothing to commit" in str(ex):
+                self.commit(message="Base commit: empty - no source archive")
+            else:
+                raise
 
     def revert_to_ref(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
     ("bind", "c8s"),
     ("boom-boot", "c8s"),
     ("boost", "c8s"),  # %setup + find + %patch
+    # ("google-noto-cjk-fonts", "c8s")  # archive 1.8G, repo ~4G
     ("python-rpm-generators", "c8s"),  # keine upstream archive, luckily %autosetup
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
     ("bind", "c8s"),
     ("boom-boot", "c8s"),
     ("boost", "c8s"),  # %setup + find + %patch
+    ("python-rpm-generators", "c8s"),  # keine upstream archive, luckily %autosetup
 ]
 
 TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,9 @@ def run_dist2src(*args, working_dir=None, **kwargs):
     working_dir = working_dir or Path.cwd()
     with cwd(working_dir):
         cli_runner = CliRunner()
+        # if you want to run debugger inside you need to do 2 things:
+        # get real std{in,out} at the level of imports because click patches it
+        # invoke pdb like this: "import pdb; pdb.Pdb(stdin=stdin, stdout=stdout).set_trace()"
         cli_runner.invoke(cli, *args, catch_exceptions=False, **kwargs)
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-
+import os
 import subprocess
 from pathlib import Path
 
@@ -41,6 +41,7 @@ def test_conversions(tmp_path: Path, package_name, branch):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
     convert_repo(package_name, dist_git_path, sg_path, branch=branch)
+    os.chdir(sg_path)
 
     run_packit(
         [


### PR DESCRIPTION
since we expect certain number of commits, we need to produce an empty
commit to preserve the expected structure

Related: https://github.com/packit/dist-git-to-source-git/issues/56#issuecomment-693362225