### PR TITLE
ensure %auto: %patch is also good

### DIFF
--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -276,8 +276,8 @@ class Dist2Src:
             return
 
         for i, line in enumerate(prep_lines):
-            if line.startswith(("%autosetup", "%autopatch")):
-                logger.info("This package uses %autosetup or %autopatch.")
+            if line.startswith(("%autosetup", "%autopatch", "%patch")):
+                logger.info("This package uses %autosetup or %[auto]patch.")
                 # cool, we're good
                 return
             elif line.startswith("%setup"):


### PR DESCRIPTION
Since we override certain macros to be sure that we have a git repo in
BUILD after we're done with -bp, we need to make sure that those
overriden macros are actually executed. We also override %patch and this
change is adding %patch to the list of macros which are fine.

If %patch is being used, we don't need to rewrite %setup to %autosetup.

With this change we are able to create a source-git repo for gcc.

Workarounds: https://bugzilla.redhat.com/show_bug.cgi?id=1881840
Related: https://github.com/packit/dist-git-to-source-git/issues/58#issuecomment-697203434