### PR TITLE
copy patches which are not applied during %prep

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,6 +28,9 @@ RUN $package_manager -y install dnf-plugins-core && \
     && $package_manager --enablerepo=PowerTools --setopt=PowerTools.module_hotfixes=true install javapackages-local \
     && $package_manager -y clean all \
     && pip3 install ipdb pytest
+# we need https://github.com/packit/packit/pull/972
+# wait for packit 0.17 to be released
+RUN pip3 install --upgrade setuptools && pip3 install wheel && pip3 install git+https://github.com/packit/packit
 
 RUN git config --system user.name "Packit" && git config --system user.email "packit"
 COPY .git /src/.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ packages = find:
 install_requires =
     click
     GitPython
-    packitos
     rebasehelper
     sh
     timeout-decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,12 @@ TEST_PROJECTS_WITH_BRANCHES = [
     ("boost", "c8s"),  # %setup + find + %patch
     # ("google-noto-cjk-fonts", "c8s")  # archive 1.8G, repo ~4G
     ("python-rpm-generators", "c8s"),  # keine upstream archive, luckily %autosetup
+    # big dawg: conditional arch patches, %setup -a 1 -a 2, patching additional archives
+    # ("gcc", "c8s"),
+    ("bpftrace", "c8s"),  # conditional patching
+    ("gdb", "c8s"),  # conditional patching
+    ("sqlite", "c8s"),  # conditional patching
+    ("zlib", "c8s"),  # conditional patching
 ]
 
 TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,21 +25,21 @@ TEST_PROJECTS_WITH_BRANCHES = [
     #    "c8s-stream-rhel",
     # ),  # %autosetup -S git_am -N + weirdness + %autopatch
     # ( "libreport", "c8s")  # -S git, they redefine "__scm_apply_git"
-    ("autofs", "c8s"),
-    ("NetworkManager", "c8s"),
-    ("dnf", "c8s"),
-    ("podman", "c8s-stream-rhel8"),
+    ("autofs", "c8s"),  # %setup, %patch, if & define
+    ("NetworkManager", "c8s"),  # %autosetup
+    ("dnf", "c8s"),  # %autosetup
+    ("podman", "c8s-stream-rhel8"),  # %autosetup -Sgit, tar fx %SOURCE1
     # alsa-lib has an empty patch file, we need support in packit for that
     # https://bugzilla.redhat.com/show_bug.cgi?id=1875768
     # https://github.com/packit/packit/issues/957
     # ("alsa-lib", "c8s"),
     # no %prep lol, https://github.com/packit/dist-git-to-source-git/issues/46
     # ("appstream-data", "c8s"),
-    ("apr", "c8s"),
-    ("arpwatch", "c8s"),
+    ("apr", "c8s"),  # %setup + %patch
+    ("arpwatch", "c8s"),  # %setup + %patch -b
     # ("atlas", "c8s")  # insanity + requires lapack-devel to be present while converting
-    ("bind", "c8s"),
-    ("boom-boot", "c8s"),
+    ("bind", "c8s"),  # %setup, conditional patches, mkdir, cp
+    ("boom-boot", "c8s"),  # %setup + %patch
     ("boost", "c8s"),  # %setup + find + %patch
     # ("google-noto-cjk-fonts", "c8s")  # archive 1.8G, repo ~4G
     ("python-rpm-generators", "c8s"),  # keine upstream archive, luckily %autosetup
@@ -52,8 +52,8 @@ TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT = [
     ),  # eaaaaasy
     ("units", "c8"),  # autosetup + files created during %prep
     ("vhostmd", "c8s"),  # -S git, eazy
-    ("autogen", "c8s"),
-    ("acpica-tools", "c8"),
+    ("autogen", "c8s"),  # %setup + %patch
+    ("acpica-tools", "c8"),  # %setup, %patch, unpack %SOURCE1, a ton of operations
     ("socat", "c8s"),  # %setup + %patch # problem with  previous commit
 ]
 

--- a/tests/test_dist2src.py
+++ b/tests/test_dist2src.py
@@ -82,3 +82,9 @@ def test_run_prep(acl):
     assert acl.joinpath("BUILD").is_dir()
     assert acl.joinpath("BUILD").joinpath("acl-2.2.53").is_dir()
     assert acl.joinpath("BUILD").joinpath("acl-2.2.53").joinpath(".git").is_dir()
+
+
+def test_copy_unapplied_patches(acl):
+    run_dist2src(["-v", "run-prep", str(acl)], working_dir=acl)
+    d2s = Dist2Src(dist_git_path=acl, source_git_path=None)
+    d2s.copy_conditional_patches()


### PR DESCRIPTION
because rpmbuild -bs needs those files - hence `packit srpm` fails

#57