### PR TITLE
add files with `git add -f` to bypass gitignore

### DIFF
--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -137,7 +137,7 @@ class GitRepo:
         if exclude:
             exclude = f":(exclude){exclude}"
             logger.debug(exclude)
-        self.repo.git.add(add or ".", exclude)
+        self.repo.git.add(add or ".", "-f", exclude)
 
     def create_tag(self, tag, branch):
         """Create a Git TAG at the tip of BRANCH"""

--- a/macros.packit
+++ b/macros.packit
@@ -5,8 +5,8 @@
 # if there are no patches, packitpatch never gets invoked and this will b/c of autosetup
 %__scm_setup_patch(q)\
 %{__git} init\
-%{__git} add .\
 %{__git} commit --allow-empty -a -m "%{NAME}-%{VERSION} base"
+%{__git} add -f .\
 
 # %{1} = absolute path to the patch
 # %{2} = patch ID
@@ -17,8 +17,8 @@
 
 %__scm_setup_git(q)\
 %{__git} init %{-q}\
-%{__git} add .\
 %{__git} commit %{-q} --allow-empty -a -m "%{NAME}-%{VERSION} base"
+%{__git} add -f .\
 
 # commit_msg contains commit message of the last commit
 %__scm_apply_git_am(qp:m:)\

--- a/macros.packit
+++ b/macros.packit
@@ -5,8 +5,8 @@
 # if there are no patches, packitpatch never gets invoked and this will b/c of autosetup
 %__scm_setup_patch(q)\
 %{__git} init\
-%{__git} commit --allow-empty -a -m "%{NAME}-%{VERSION} base"
 %{__git} add -f .\
+%{__git} commit -q --allow-empty -a -m "%{NAME}-%{VERSION} base"
 
 # %{1} = absolute path to the patch
 # %{2} = patch ID
@@ -17,8 +17,8 @@
 
 %__scm_setup_git(q)\
 %{__git} init %{-q}\
-%{__git} commit %{-q} --allow-empty -a -m "%{NAME}-%{VERSION} base"
 %{__git} add -f .\
+%{__git} commit -q --allow-empty -a -m "%{NAME}-%{VERSION} base"
 
 # commit_msg contains commit message of the last commit
 %__scm_apply_git_am(qp:m:)\

--- a/packitpatch
+++ b/packitpatch
@@ -15,7 +15,9 @@ second_to_last_dir=$(basename $(dirname ${top_level_git_path}))
 # the git repo exists here
 if [ $second_to_last_dir != "BUILD" ]; then
   git init
-  git add .
+  # we are doing -f to bypass .gitignore which can mask packit.yaml or the specfile
+  # https://github.com/packit/dist-git-to-source-git/issues/66#issuecomment-694284493
+  git add -f .
   # that PWD magic prints the name of the PWD, which usually is NAME-VERSION
   git commit --allow-empty -a -m "${PWD##*/} base"
 fi
@@ -45,6 +47,6 @@ if [ "$patch_id" != "%{2}" ]; then
   printf -v commit_message "${commit_message}\nlocation_in_specfile: ${patch_id}"
 fi
 
-git add .
+git add -f .
 # patches can be empty, rpmbuild if fine with it
 git commit -m "$commit_message" --allow-empty

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
     # ("gcc", "c8s"),
     ("gdb", "c8s"),  # conditional patching, a ton of if's and addition of more sources
     ("sqlite", "c8s"),  # conditional patching + autoconf
+    ("haproxy", "c8s"),  # they ignore our files
 ]
 
 TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT = [


### PR DESCRIPTION
some tarballs have .gitignores which ignore our files: packit.yaml,
*.spec, or additional sources: when doing -f we can bypass this
limitation

Resolves: #66