### PR TITLE
`%setup` → `%autosetup -N` unless `-aN -aM`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ check:
 
 # if you want to inspect repos which are created during a test run, do `-v /tmp:/tmp` and navigate to /tmp/pytest*/...
 # sadly this doesn't work in CI (SELinux?)
+# -u $(id -u) doesn't work on F33
 check-in-container:
 	$(CONTAINER_ENGINE) run \
 		-ti --rm \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
         "unbound",
         "c8",
     ),  # again, another level of directories and patches applied in a subdir
+    # ("hyperv-daemons", "c8"),  # no archive, source code is %SOURCEXXX, does not update
 ]
 
 # these packages only have a single commit in the respective dist-git branch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,13 @@ TEST_PROJECTS_WITH_BRANCHES = [
     ("gdb", "c8s"),  # conditional patching, a ton of if's and addition of more sources
     ("sqlite", "c8s"),  # conditional patching + autoconf
     ("haproxy", "c8s"),  # they ignore our files
+    # ("openblas", "c8"),  # openblas-0.3.3/OpenBLAS-0.3.3/
+    # ("fuse", "c8"),  # 2 libraries being built in a single buildroot, we cannot make
+    #                  # a reliable source-git for this
+    (
+        "unbound",
+        "c8",
+    ),  # again, another level of directories and patches applied in a subdir
 ]
 
 # these packages only have a single commit in the respective dist-git branch
@@ -55,6 +62,8 @@ TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT = [
     ("acpica-tools", "c8"),  # %setup, %patch, unpack %SOURCE1, a ton of operations
     ("socat", "c8s"),  # %setup + %patch # problem with  previous commit
     ("meanwhile", "c8"),  # -p0 + -p1 patches
+    ("nss-util", "c8"),  # double nested dir: nss-util-3.39/nss/ and `cd nss` in %prep
+    ("metis", "c8"),  # %setup -qc && pushd %{name}-%{version}
 ]
 
 


### PR DESCRIPTION
Sometimes packages have multiple sources (= archives) which they unpack
during %prep in different ways. This can be done with `%setup -aN -aM`.
Sadly `%autosetup -aN -aM` does not work: https://bugzilla.redhat.com/show_bug.cgi?id=1881840

So we need to turn back into overwriting %setup unless we detect this
use case.

But the eternal problem with patches applied in a subdir persists.

Fixes some of #92