### PR TITLE
source-git as a single commit repo

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -15,6 +15,7 @@
     parent: base
     description: Run tests
     run: files/zuul-tests.yaml
+    timeout: 2400 # 40 minutes
 
 - job:
     name: dist2src-deployment-tests

--- a/dist2src/constants.py
+++ b/dist2src/constants.py
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+"""
+This module covers integration between external entities
+and emulates functionality... just kidding, it's just constants.
+"""
+from typing import Iterable
+
+
+# these packages have complex %prep's which cannot be turned
+# into a proper source-git repo - hence we just run the %prep
+# and initiate a single-commit repo for these
+VERY_VERY_HARD_PACKAGES: Iterable[str] = (
+    "gcc",
+    "hyperv-daemons",
+    "kernel",
+    "libreport",
+)
+
+# build and test targets
+TARGETS = ["centos-stream-x86_64"]
+START_TAG = "sg-start"
+POST_CLONE_HOOK = "post-clone"
+AFTER_PREP_HOOK = "after-prep"
+TEMP_SG_BRANCH = "updates"

--- a/dist2src/constants.py
+++ b/dist2src/constants.py
@@ -4,8 +4,7 @@
 This module covers integration between external entities
 and emulates functionality... just kidding, it's just constants.
 """
-from typing import Iterable
-
+from typing import Iterable, Dict, Any
 
 # these packages have complex %prep's which cannot be turned
 # into a proper source-git repo - hence we just run the %prep
@@ -23,3 +22,16 @@ START_TAG = "sg-start"
 POST_CLONE_HOOK = "post-clone"
 AFTER_PREP_HOOK = "after-prep"
 TEMP_SG_BRANCH = "updates"
+
+HOOKS: Dict[str, Dict[str, Any]] = {
+    "kernel": {
+        # %setup -c creates another directory level but patches don't expect it
+        AFTER_PREP_HOOK: (
+            "set -e; "
+            "shopt -s dotglob nullglob && "  # so that * would match dotfiles as well
+            "cd BUILD/kernel-4.18.0-*.el8/ && "
+            "mv ./linux-4.18.0-*.el8.x86_64/* . && "
+            "rmdir ./linux-4.18.0-*.el8.x86_64"
+        )
+    },
+}

--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Union, Set
 
@@ -16,14 +17,10 @@ from packit.patches import PatchMetadata
 from packit.specfile import Specfile
 from yaml import dump
 
+from dist2src.constants import AFTER_PREP_HOOK, TEMP_SG_BRANCH, START_TAG, TARGETS
+
 logger = logging.getLogger(__name__)
 
-# build and test targets
-TARGETS = ["centos-stream-x86_64"]
-START_TAG = "sg-start"
-POST_CLONE_HOOK = "post-clone"
-AFTER_PREP_HOOK = "after-prep"
-TEMP_SG_BRANCH = "updates"
 
 # would be better to have them externally (in a file at least)
 # but since this is only for kernel, it should be good enough
@@ -58,7 +55,7 @@ def get_hook(package_name: str, hook_name: str) -> Optional[str]:
     return HOOKS.get(package_name, {}).get(hook_name, None)
 
 
-def get_build_dir(path: Path):
+def get_build_dir(path: Path) -> Path:
     build_dirs = [d for d in (path / "BUILD").iterdir() if d.is_dir()]
     if len(build_dirs) > 1:
         raise RuntimeError(f"More than one directory found in {path / 'BUILD'}")
@@ -324,14 +321,24 @@ class Dist2Src:
 
         self.dist_git_spec.save()
 
-    def run_prep(self):
+    def run_prep(self, ensure_autosetup: bool = True):
         """
         run `rpmbuild -bp` in the dist-git repo to get a git-repo
         in the %prep phase so we can pick the commits in the source-git repo
+
+        @param ensure_autosetup: replace %setup with %autosetup if possible
         """
         rpmbuild = sh.Command("rpmbuild")
 
         with sh.pushd(self.dist_git_path):
+            BUILD_dir = Path("BUILD")
+            if BUILD_dir.is_dir():
+                # remove BUILD/ dir if it exists
+                # for single-commit repos, this is problem in case of a rebase
+                # there would be 2 directories which the get_build_dir() function
+                # would not handle
+                shutil.rmtree(BUILD_dir)
+
             cwd = Path.cwd()
             logger.debug(f"Running rpmbuild in {cwd}")
             specfile_path = Path(f"SPECS/{cwd.name}.spec")
@@ -344,9 +351,10 @@ class Dist2Src:
             ]
             if self.log_level:  # -vv can be super-duper verbose
                 rpmbuild_args.append("-" + "v" * self.log_level)
-            rpmbuild_args.append(specfile_path)
+            rpmbuild_args.append(str(specfile_path))
 
-            self._enforce_autosetup()
+            if ensure_autosetup:
+                self._enforce_autosetup()
 
             try:
                 running_cmd = rpmbuild(*rpmbuild_args)
@@ -423,7 +431,78 @@ class Dist2Src:
         # get all the patch-commits
         self.rebase_patches(from_branch=TEMP_SG_BRANCH, to_branch=dest_branch)
 
-    def add_packit_config(self):
+    def copy_prep_content(self):
+        """
+        For the single-commit source-git repos, we don't care about the
+        git repo created in BUILD/<PACKAGE-VERSION> since it's wrong
+        hence we only copy the content to the source-git repo and commit it
+        """
+        dist_git_BUILD_path = get_build_dir(self.dist_git_path).absolute()
+
+        for entry in dist_git_BUILD_path.iterdir():
+            if entry.is_file():
+                logger.debug(f"copy {entry} -> {self.source_git_path}")
+                shutil.copy2(entry, self.source_git_path)
+            else:  # it's a dir
+                if entry.name == ".git":
+                    continue
+                dst = self.source_git_path.joinpath(entry.name)
+                logger.debug(f"copy {entry} -> {dst}")
+                shutil.copytree(entry, dst)
+
+    def convert_single_commit(self, origin_branch: str, dest_branch: str):
+        """
+        Convert a dist-git repository into a source-git repo in a single
+        source-git commit - we use this strategy for packages with complex
+        %prep sections (multiple archives, patching subdir, redefining %scm* macros....)
+        which cannot be converted well with the convert() function
+        """
+        logger.info(
+            "Doing a single-commit source-git repo "
+            f"for {self.package_name}:{origin_branch}"
+        )
+        self.dist_git.checkout(branch=origin_branch)
+        if self.source_git.repo.active_branch.name != dest_branch:
+            self.source_git.checkout(branch=dest_branch, orphan=True)
+
+        # if it's an update, we need to remove everything except for .git
+        for path in self.source_git_path.iterdir():
+            if path.name == ".git":
+                continue
+            logger.debug(f"rm {path}")
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+
+        # expand dist-git and pull the history
+        self.fetch_archive()
+        self.run_prep(ensure_autosetup=False)
+        self.copy_prep_content()
+
+        # configure packit
+        self.add_packit_config(commit=False)
+        self.copy_spec()
+        self.copy_all_sources(with_patches=True)
+        self.source_git.stage(add=".")
+
+        try:
+            commit_msg_suffix = (
+                subprocess.check_output(
+                    ["git", "describe", "--abbrev=0"], cwd=self.dist_git_path
+                )
+                .decode()
+                .strip()
+            )
+        except subprocess.CalledProcessError:
+            logger.error("couldn't obtain latest git-tag from the dist-git repo")
+            commit_msg_suffix = self.package_name
+        self.source_git.commit(message=f"Source-git repo for {commit_msg_suffix}")
+
+        # mark the last upstream commit
+        self.source_git.create_tag(tag=START_TAG, branch=dest_branch)
+
+    def add_packit_config(self, commit: bool = False):
         """
         Add packit config to the source-git repo.
         """
@@ -447,19 +526,28 @@ class Dist2Src:
             ],
         }
         self.source_git_path.joinpath(".packit.yaml").write_text(dump(config))
-        self.source_git.stage(add=".packit.yaml")
-        self.source_git.commit(message=".packit.yaml")
+        if commit:
+            self.source_git.stage(add=".packit.yaml")
+            self.source_git.commit(message=".packit.yaml")
 
-    def copy_all_sources(self):
-        """Copy 'SOURCES/*' from a dist-git repo to a source-git repo."""
+    def copy_all_sources(self, with_patches: bool = False):
+        """
+        Copy 'SOURCES/*' from a dist-git repo to a source-git repo.
+
+        @param with_patches: copy patch files as well
+        """
         dg_path = self.dist_git_path / "SOURCES"
         sg_path = self.source_git_path / "SPECS"
         logger.info(f"Copy all sources from {dg_path} to {sg_path}.")
 
-        for file_ in self.dist_git_spec.get_sources():
-            file_dest = sg_path / Path(file_).name
-            logger.debug(f"copying {file_} to {file_dest}")
-            shutil.copy2(file_, file_dest)
+        sources = self.dist_git_spec.get_sources()[:]
+        if with_patches:
+            sources += (x.path for x in self.dist_git_spec.get_patches())
+
+        for source in sources:
+            source_dest = sg_path / Path(source).name
+            logger.debug(f"copying {source} to {source_dest}")
+            shutil.copy2(source, source_dest)
 
     def copy_conditional_patches(self):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
     # %autosetup -S git_am + needs https://koji.mbox.centos.org/koji/taginfo?tagID=342
     ("pacemaker", "c8s"),
     ("systemd", "c8s"),  # -S git_am
-    # ("kernel", "c8s"),  # !!!
+    ("kernel", "c8s"),  # !!!
     # (
     #    "qemu-kvm",
     #    "c8s-stream-rhel",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
     #    "libvirt",
     #    "c8s-stream-rhel",
     # ),  # %autosetup -S git_am -N + weirdness + %autopatch
-    # ( "libreport", "c8s")  # -S git, they redefine "__scm_apply_git"
+    ("libreport", "c8s"),  # -S git, they redefine "__scm_apply_git"
     ("podman", "c8s-stream-rhel8"),  # %autosetup -Sgit, tar fx %SOURCE1
     # alsa-lib has an empty patch file, we need support in packit for that
     # https://bugzilla.redhat.com/show_bug.cgi?id=1875768
@@ -38,7 +38,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
     # ("google-noto-cjk-fonts", "c8s")  # archive 1.8G, repo ~4G
     ("python-rpm-generators", "c8s"),  # keine upstream archive, luckily %autosetup
     # big dawg: conditional arch patches, %setup -a 1 -a 2, patching additional archives
-    # ("gcc", "c8s"),
+    ("gcc", "c8s"),
     ("gdb", "c8s"),  # conditional patching, a ton of if's and addition of more sources
     ("sqlite", "c8s"),  # conditional patching + autoconf
     ("haproxy", "c8s"),  # they ignore our files
@@ -49,7 +49,7 @@ TEST_PROJECTS_WITH_BRANCHES = [
         "unbound",
         "c8",
     ),  # again, another level of directories and patches applied in a subdir
-    # ("hyperv-daemons", "c8"),  # no archive, source code is %SOURCEXXX, does not update
+    ("hyperv-daemons", "c8"),  # no archive, source code is %SOURCEXXX, does not update
 ]
 
 # these packages only have a single commit in the respective dist-git branch

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -18,6 +18,10 @@ from tests.conftest import (
 
 @pytest.mark.parametrize("package_name,branch", TEST_PROJECTS_WITH_BRANCHES)
 def test_update(tmp_path: Path, package_name, branch):
+    """
+    perform an update from a previous dist-git commit (HEAD~1)
+    to the last one (HEAD)
+    """
     dist_git_path = tmp_path / "d" / package_name
     sg_path = tmp_path / "s" / package_name
     dist_git_path.mkdir(parents=True)
@@ -55,10 +59,8 @@ def test_update(tmp_path: Path, package_name, branch):
         [
             "--debug",
             "srpm",
-            "--output",
-            str(sg_path / f"{package_name}.src.rpm"),
-            str(sg_path),
-        ]
+        ],
+        working_dir=sg_path,  # _srcrpmdir rpm macro is set to /, let's CWD then
     )
     srpm_path = next(sg_path.glob("*.src.rpm"))
     assert srpm_path.exists()
@@ -78,6 +80,9 @@ def test_update(tmp_path: Path, package_name, branch):
     "package_name,branch", TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT
 )
 def test_update_from_same_commit(tmp_path: Path, package_name, branch):
+    """
+    run an update twice from the same commit
+    """
     dist_git_path = tmp_path / "d" / package_name
     sg_path = tmp_path / "s" / package_name
     dist_git_path.mkdir(parents=True)
@@ -146,6 +151,7 @@ def test_update_from_same_commit(tmp_path: Path, package_name, branch):
     ],
 )
 def test_update_source(tmp_path: Path, package_name, branch, old_version):
+    """ perform an update from a specific ref to the last commit """
     dist_git_path = tmp_path / "d" / package_name
     sg_path = tmp_path / "s" / package_name
     dist_git_path.mkdir(parents=True)


### PR DESCRIPTION
    create a single-commit source-git from very hard packages

    This is simple: we now have a static list of packages
    VERY_VERY_HARD_PACKAGES which are "very very hard" and don't pass our
    magic %prep expansion.   

    The solution is to run %prep the same way (to benefit from packitpatch),
    discard the generated .git repo and then create a repo (or an update)
    with just a single commit: all source and patches copied.

    It's pretty ugly (patch files copied, not as commits) but it's the best
    we can: some repo > no repo


TODO:
* [x] commit message explanation
* [x] gcc passes tests
* [x] gcc can be updated
* [x] one more package passes conversion and update [hyperv-daemons]
* [x] commit message
* [x] shorter command name
* [x] make kernel pass