### PR TITLE
tests: update old source-git repo with latest changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 import os
+import subprocess
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -86,3 +87,25 @@ def run_packit(*args, working_dir=None, **kwargs):
     with cwd(working_dir):
         cli_runner = CliRunner()
         cli_runner.invoke(packit_base, *args, catch_exceptions=False, **kwargs)
+
+
+def clone_package(
+    package_name: str,
+    dist_git_path: str,
+    branch: str = "c8s",
+    namespace: str = "rpms",
+    stg: bool = False,
+):
+    """
+    clone selected package from git.[stg.]centos.org
+    """
+    subprocess.check_call(
+        [
+            "git",
+            "clone",
+            "-b",
+            branch,
+            f"https://git{'.stg' if stg else ''}.centos.org/{namespace}/{package_name}.git",
+            dist_git_path,
+        ]
+    )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -12,20 +12,12 @@ from tests.conftest import (
     TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT,
     run_dist2src,
     run_packit,
+    clone_package,
 )
 
 
 def convert_repo(package_name, dist_git_path, sg_path, branch="c8s"):
-    subprocess.check_call(
-        [
-            "git",
-            "clone",
-            "-b",
-            branch,
-            f"https://git.centos.org/rpms/{package_name}.git",
-            dist_git_path,
-        ]
-    )
+    clone_package(package_name, str(dist_git_path), branch=branch)
     run_dist2src(
         ["-vvv", "convert", f"{dist_git_path}:{branch}", f"{sg_path}:{branch}"]
     )

--- a/tests/test_dist2src.py
+++ b/tests/test_dist2src.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from dist2src.core import Dist2Src
+from tests.conftest import clone_package
 from tests.test_convert import run_dist2src
 
 this_dir = Path(__file__).parent
@@ -144,10 +145,7 @@ def test_no_backup(tmp_path: Path):
     d = tmp_path / "d"
     d.mkdir()
     dist_git_path = d / package_name
-    subprocess.check_call(
-        ["git", "clone", f"https://git.centos.org/rpms/{package_name}.git"], cwd=d
-    )
-    subprocess.check_call(["git", "checkout", "c8"], cwd=dist_git_path)
+    clone_package(package_name, str(dist_git_path), branch="c8")
     b = dist_git_path / "BUILD" / "hyperv-daemons-0"
     run_dist2src(["-v", "run-prep", str(dist_git_path)], working_dir=dist_git_path)
     assert b.is_dir()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -13,6 +13,7 @@ from tests.conftest import (
     TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT,
     run_dist2src,
     run_packit,
+    clone_package,
 )
 
 
@@ -27,16 +28,7 @@ def test_update(tmp_path: Path, package_name, branch):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
 
-    subprocess.check_call(
-        [
-            "git",
-            "clone",
-            "-b",
-            branch,
-            f"https://git.centos.org/rpms/{package_name}.git",
-            dist_git_path,
-        ]
-    )
+    clone_package(package_name, str(dist_git_path), branch=branch)
     subprocess.check_call(
         ["git", "reset", "--hard", "HEAD~1"],
         cwd=dist_git_path,
@@ -88,16 +80,7 @@ def test_update_from_same_commit(tmp_path: Path, package_name, branch):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
 
-    subprocess.check_call(
-        [
-            "git",
-            "clone",
-            "-b",
-            branch,
-            f"https://git.centos.org/rpms/{package_name}.git",
-            dist_git_path,
-        ]
-    )
+    clone_package(package_name, str(dist_git_path), branch=branch)
 
     run_dist2src(
         ["-vvv", "convert", f"{dist_git_path}:{branch}", f"{sg_path}:{branch}"]
@@ -157,16 +140,7 @@ def test_update_source(tmp_path: Path, package_name, branch, old_version):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
 
-    subprocess.check_call(
-        [
-            "git",
-            "clone",
-            "-b",
-            branch,
-            f"https://git.centos.org/rpms/{package_name}.git",
-            dist_git_path,
-        ]
-    )
+    clone_package(package_name, str(dist_git_path), branch=branch)
     subprocess.check_call(
         ["git", "reset", "--hard", old_version],
         cwd=dist_git_path,


### PR DESCRIPTION
Fixes #103 (by providing a test case which passes)

@jpopelka sadly I wasn't able to reproduce, please let me know if the provided use case works on your laptop (I run it with `make check-in-container OPTS='-v /tmp:/tmp' TEST_TARGET='tests/test_update.py::test_update_apr'`