### PR TITLE
Built worker image on top of the centos:8

### DIFF
--- a/files/Containerfile.worker
+++ b/files/Containerfile.worker
@@ -1,10 +1,15 @@
 # Celery worker which runs tasks from centosmsg listener
 
-FROM docker.io/usercont/base
+ARG base_image=centos:8
+ARG package_manager
+FROM $base_image
 
+ENV package_manager ${package_manager:-yum -y}
 COPY files/install-deps-worker.yml /src/
-RUN ansible-playbook -vv -c local -i localhost, /src/install-deps-worker.yml \
-    && dnf clean all
+RUN $package_manager install epel-release \
+    && $package_manager install ansible \
+    && ansible-playbook -vv -c local -i localhost, /src/install-deps-worker.yml \
+    && $package_manager clean all
 
 COPY setup.py setup.cfg files/run_worker.sh /src/
 COPY dist2src/ /src/dist2src/

--- a/files/install-deps-worker.yml
+++ b/files/install-deps-worker.yml
@@ -12,16 +12,23 @@
           - python3-click
           - python3-GitPython
           - python3-sh
-          - rebase-helper
           - python3-timeout-decorator
           - python3-celery
           - python3-redis
           - python3-lazy-object-proxy
           - redis # redis-cli for debugging
           - python3-cccolutils # packitos dependency, otherwise we'd need gcc to compile it
+          - gcc
+          - git
+          - krb5-devel
+          - python3-devel
+          - python3-pip
+          - rpm-build
     - name: Install pip deps
       pip:
         name:
-          - sentry-sdk
+          - sentry-sdk==0.19.1
+          - rebasehelper==0.23.1
+        executable: pip3
     - name: Chek if all pip packages have all dependencies installed
       command: pip3 check


### PR DESCRIPTION
The sentry-sdk and rebase-helper packages are installed from GitHub via pip.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>