### PR TITLE
create a source-git branch if it's not present

### DIFF
--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -165,6 +165,7 @@ class GitRepo:
         self.commit(commit_message, body=commit_body)
         # clear the working-tree
         self.repo.git.reset("HEAD", hard=True)
+        self.clean()  # `reset --hard HEAD` is not enough to clean untracked files
 
     def clean(self):
         """

--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -175,7 +175,7 @@ class GitRepo:
         # to remove the submodules/git repos as well.
         self.repo.git.clean("-xdff")
 
-    def fast_forwad(self, branch, to_ref):
+    def fast_forward(self, branch, to_ref):
         self.checkout(branch)
         self.repo.git.merge(to_ref, ff_only=True)
 
@@ -663,4 +663,4 @@ class Dist2Src:
         self.perform_convert(origin_branch=origin_branch, dest_branch=new_dest_branch)
 
         # fast-forward old branch
-        self.source_git.fast_forwad(branch=dest_branch, to_ref=new_dest_branch)
+        self.source_git.fast_forward(branch=dest_branch, to_ref=new_dest_branch)

--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -137,6 +137,11 @@ class GitRepo:
             if theirs
             else {}
         )
+        if self.repo.is_dirty():
+            raise RuntimeError(
+                "We wanted to cherry-pick the base commit but the source-git repo "
+                "is dirty when it shouldn't be."
+            )
         try:
             self.repo.git.cherry_pick(f"{from_branch}~{num_commits - 1}", **git_options)
         except GitCommandError as ex:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,6 @@ from packit.cli.packit_base import packit_base
 from packit.utils import cwd
 
 TEST_PROJECTS_WITH_BRANCHES = [
-    ("rpm", "c8s"),  # %autosetup and lots of patches
-    ("drpm", "c8s"),  # easy
     # %autosetup -S git_am + needs https://koji.mbox.centos.org/koji/taginfo?tagID=342
     ("pacemaker", "c8s"),
     ("systemd", "c8s"),  # -S git_am
@@ -55,10 +53,6 @@ TEST_PROJECTS_WITH_BRANCHES = [
 
 # these packages only have a single commit in the respective dist-git branch
 TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT = [
-    (
-        "HdrHistogram_c",
-        "c8s",
-    ),  # eaaaaasy
     ("units", "c8"),  # autosetup + files created during %prep
     ("vhostmd", "c8s"),  # -S git, eazy
     ("acpica-tools", "c8"),  # %setup, %patch, unpack %SOURCE1, a ton of operations

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -182,21 +182,31 @@ def test_update_source(tmp_path: Path, package_name, branch, old_version):
         )
 
 
-def test_update_apr(tmp_path: Path):
+@pytest.mark.parametrize(
+    "package",
+    (
+        "apr",
+        "meson",
+        "ostree",
+        "pacemaker",
+        "vala",
+        "upower",
+    ),
+)
+def test_update_existing(tmp_path: Path, package):
     """
     Jirka found an issue that we cannot update several packages
     which were created by an old version of d2s, one of them is apr
     """
-    package_name = "apr"
-    dist_git_path = tmp_path / "d" / package_name
+    dist_git_path = tmp_path / "d" / package
     dg_branch = "c8s"
-    source_git_path = tmp_path / "s" / package_name
-    sg_branch = "c8"
-    clone_package(package_name, str(dist_git_path), branch=dg_branch)
+    source_git_path = tmp_path / "s" / package
+    sg_branch = "c8s"
+    clone_package(package, str(dist_git_path), branch=dg_branch)
     clone_package(
-        package_name,
+        package,
         str(source_git_path),
-        branch=sg_branch,
+        branch="master",
         namespace="source-git",
         stg=True,
     )


### PR DESCRIPTION
when creating an orphan branch, git preserves files in the index
which we don't want

the test case is also corrected

@jpopelka I welcome more packages where I can try this

Fixes #103 