### PR TITLE
[worker] git push --tags --force

### DIFF
--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -100,4 +100,5 @@ class Processor:
         d2s.convert(branch, branch)
 
         # Push the result to source-git.
-        src_git_repo.git.push("origin", branch)
+        # Update moves sg-start tag, we need --tags --force to move it in remote.
+        src_git_repo.git.push("origin", branch, tags=True, force=True)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -5,8 +5,8 @@ import os
 import logging
 import shutil
 import git
-import flexmock
 
+from flexmock import flexmock
 from pathlib import Path
 from ogr import PagureService
 from dist2src.worker.processor import Processor
@@ -132,7 +132,9 @@ def test_conversion(caplog):
     d2s.should_receive("convert").with_args("c8s", "c8s")
 
     # Result is pushed.
-    src_git_repo.git.should_receive("push").with_args("origin", "c8s").once()
+    src_git_repo.git.should_receive("push").with_args(
+        "origin", "c8s", tags=True, force=True
+    ).once()
 
     Processor().process_message(
         {


### PR DESCRIPTION
See https://git.stg.centos.org/source-git/ostree/commits/c8s where the `sg-start` tag should have been moved to the `Add sources defined in the spec file` commit.