### PR TITLE
processor: Push the branch and tags separately

### DIFF
--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -105,7 +105,7 @@ class Processor:
         d2s.convert(branch, branch)
 
         # Push the result to source-git.
-
+        src_git_repo.git.push("origin", branch)
         # Update moves sg-start tag, we need --tags --force to move it in remote.
-        src_git_repo.git.push("origin", branch, tags=True, force=True)
+        src_git_repo.git.push("origin", tags=True, force=True)
         Pushgateway().push_created_update()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -141,8 +141,11 @@ def test_conversion(caplog):
     )
     d2s.should_receive("convert").with_args("c8s", "c8s")
     # Result is pushed.
+    src_git_repo.git.should_receive("push").with_args("origin", "c8s").once()
+
+    # Start tag is force pushed
     src_git_repo.git.should_receive("push").with_args(
-        "origin", "c8s", tags=True, force=True
+        "origin", tags=True, force=True
     ).once()
 
     flexmock(Pushgateway).should_receive("push_received_message").with_args(


### PR DESCRIPTION
It seems that branches cannot be force-pushed (and they don't need to
be), so first push the branch that was updated, then force push any tags
that might be updated.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>