### PR TITLE
Set up logging to a file

### DIFF
--- a/dist2src/worker/logging.py
+++ b/dist2src/worker/logging.py
@@ -1,0 +1,30 @@
+import logging
+from datetime import datetime
+from pathlib import Path
+
+
+def set_logging_to_file(
+    repo_name: str, commit_sha: str, logs_dir: Path = Path("/log-files/")
+):
+    """
+    Set logging to a file for conversion.
+    :param repo_name: name of the repository
+    :param commit_sha: commit SHA
+    :param logs_dir: dir where the logs are stored
+    :return:
+    """
+    logger = logging.getLogger("dist2src")
+    logger.setLevel(logging.DEBUG)
+    log_dir = logs_dir / repo_name
+    log_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{commit_sha}_{datetime.now().isoformat(timespec='seconds')}.log"
+
+    file_handler = logging.FileHandler(log_dir / filename)
+    formatter = logging.Formatter(
+        "[%(asctime)s %(filename)s %(levelname)s] %(message)s"
+    )
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.DEBUG)
+
+    logger.addHandler(file_handler)
+    logger.info(f"Processing repository {repo_name}, commit SHA {commit_sha}.")

--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -11,6 +11,7 @@ import git
 from ogr import PagureService
 from dist2src.core import Dist2Src
 from dist2src.worker.monitoring import Pushgateway
+from dist2src.worker.logging import set_logging_to_file
 
 logger = getLogger(__name__)
 
@@ -65,6 +66,8 @@ class Processor:
             return
 
         Pushgateway().push_received_message(ignored=False)
+        set_logging_to_file(repo_name=name, commit_sha=event["end_commit"])
+
         # Clone repo from rpms/ and checkout the branch.
         dist_git_dir = workdir / fullname
         shutil.rmtree(dist_git_dir, ignore_errors=True)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,17 @@
+import os
+
+from pathlib import Path
+from dist2src.worker.logging import set_logging_to_file
+
+
+def test_set_logging_to_file(tmpdir):
+    set_logging_to_file("acl", "00ab78", Path(tmpdir))
+
+    expected_dir = Path(tmpdir / "acl")
+    assert expected_dir.is_dir()
+
+    files = os.listdir(expected_dir)
+    assert len(files) == 1
+
+    file = files[0]
+    assert file.startswith("00ab78_")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -5,6 +5,7 @@ import os
 import logging
 import shutil
 import git
+from dist2src.worker import logging as our_logging
 
 from flexmock import flexmock
 from pathlib import Path
@@ -149,6 +150,8 @@ def test_conversion(caplog):
         ignored=False
     ).once()
     flexmock(Pushgateway).should_receive("push_created_update").once()
+
+    flexmock(our_logging).should_receive("set_logging_to_file")
 
     Processor().process_message(
         {


### PR DESCRIPTION
`/log-files` structure:
├── repo1
│   ├── 0a0c838_2020-11-10T10:19:06.log
│   └── af0c838_2020-11-10T10:19:06.log
├── repo2
│   ├──af0c838_2020-11-10T10:19:06.log


Logs format:
`[2020-11-09 16:09:04,845 logging.py INFO] Processing repository repo1, commit SHA 0a0c838.`
