### PR TITLE
[processor] Move the try-block to separate method

### DIFF
--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -6,7 +6,10 @@ import re
 import shutil
 from logging import getLogger
 from pathlib import Path
+from typing import Optional
+
 import git
+from ogr.services.pagure import PagureProject
 
 from ogr import PagureService
 from dist2src.core import Dist2Src
@@ -17,49 +20,58 @@ logger = getLogger(__name__)
 
 
 class Processor:
+    def __init__(self):
+        self.workdir = Path(os.getenv("D2S_WORKDIR", "/workdir"))
+        self.dist_git_host = os.getenv("D2S_DIST_GIT_HOST", "git.centos.org")
+        self.src_git_host = os.getenv("D2S_SRC_GIT_HOST", "git.stg.centos.org")
+        self.src_git_token = os.getenv("D2S_SRC_GIT_TOKEN")
+        self.dist_git_namespace = os.getenv("D2S_DIST_GIT_NAMESPACE", "rpms")
+        self.src_git_namespace = os.getenv("D2S_SRC_GIT_NAMESPACE", "source-git")
+        self.branches_watched = os.getenv("D2S_BRANCHES_WATCHED", "c8s,c8").split(",")
+
+        self.fullname: Optional[str] = None
+        self.name: Optional[str] = None
+        self.branch: Optional[str] = None
+        self.end_commit: Optional[str] = None
+
     def process_message(self, event: dict, **kwargs):
-        workdir = Path(os.getenv("D2S_WORKDIR", "/workdir"))
-        dist_git_host = os.getenv("D2S_DIST_GIT_HOST", "git.centos.org")
-        src_git_host = os.getenv("D2S_SRC_GIT_HOST", "git.stg.centos.org")
-        src_git_token = os.getenv("D2S_SRC_GIT_TOKEN")
-        dist_git_namespace = os.getenv("D2S_DIST_GIT_NAMESPACE", "rpms")
-        src_git_namespace = os.getenv("D2S_SRC_GIT_NAMESPACE", "source-git")
-        branches_watched = os.getenv("D2S_BRANCHES_WATCHED", "c8s,c8").split(",")
-        fullname = event["repo"]["fullname"]
-        name = event["repo"]["name"]
-        branch = event["branch"]
+        self.fullname = event["repo"]["fullname"]
+        self.name = event["repo"]["name"]
+        self.branch = event["branch"]
+        self.end_commit = event["end_commit"]
 
         logger.info(f"Processing message with {event}")
         # Is this a repository in the rpms namespace?
-        if not fullname.startswith(dist_git_namespace):
+        if not self.fullname.startswith(self.dist_git_namespace):
             logger.info(
-                f"Ignore update event for {fullname}. Not in the '{dist_git_namespace}' namespace."
+                f"Ignore update event for {self.fullname}. "
+                f"Not in the '{self.dist_git_namespace}' namespace."
             )
             Pushgateway().push_received_message(ignored=True)
             return
 
         # Should this branch be updated?
-        if event["branch"] not in branches_watched:
+        if self.branch not in self.branches_watched:
             logger.info(
-                f"Ignore update event for {fullname}. "
-                f"Branch {event['branch']!r} is not one of the "
-                f"watched branches: {branches_watched}."
+                f"Ignore update event for {self.fullname}. "
+                f"Branch {self.branch!r} is not one of the "
+                f"watched branches: {self.branches_watched}."
             )
             Pushgateway().push_received_message(ignored=True)
             return
 
         # Does this repository have a source-git equvalent?
         service = PagureService(
-            instance_url=f"https://{src_git_host}", token=src_git_token
+            instance_url=f"https://{self.src_git_host}", token=self.src_git_token
         )
         # When the namespace is a fork, "fork" is singular when accessing
         # the API, but plural in the Git URLs.
         # Keep this here, so we can test with forks.
-        namespace = re.sub(r"^forks\/", "fork/", src_git_namespace)
-        project = service.get_project(namespace=namespace, repo=name)
+        namespace = re.sub(r"^forks\/", "fork/", self.src_git_namespace)
+        project = service.get_project(namespace=namespace, repo=self.name)
         if not project.exists():
             logger.info(
-                f"Ignore update event for {fullname}. "
+                f"Ignore update event for {self.fullname}. "
                 "The corresponding source-git repo does not exist."
             )
             Pushgateway().push_received_message(ignored=True)
@@ -67,54 +79,55 @@ class Processor:
 
         Pushgateway().push_received_message(ignored=False)
         file_handler = set_logging_to_file(
-            repo_name=name, commit_sha=event["end_commit"]
+            repo_name=self.name, commit_sha=self.end_commit
         )
 
         try:
-            # Clone repo from rpms/ and checkout the branch.
-            dist_git_dir = workdir / fullname
-            shutil.rmtree(dist_git_dir, ignore_errors=True)
-            dist_git_repo = git.Repo.clone_from(
-                f"https://{dist_git_host}/{fullname}.git", dist_git_dir
-            )
-            dist_git_repo.git.checkout(branch)
-
-            # Check if the commit is the one we are expecting.
-            if dist_git_repo.branches[branch].commit.hexsha != event["end_commit"]:
-                logger.warning(
-                    f"HEAD of {branch} is not matching {event['end_commit']}, as expected."
-                )
-
-            # Clone repo from source-git/ using ssh, so it can be pushed later on.
-            src_git_ssh_url = project.get_git_urls()["ssh"]
-            src_git_dir = workdir / src_git_namespace / name
-            shutil.rmtree(src_git_dir, ignore_errors=True)
-            src_git_repo = git.Repo.clone_from(
-                src_git_ssh_url,
-                src_git_dir,
-            )
-
-            # Check-out the source-git branch, if already exists,
-            # so that 'convert' knows that this is an update.
-            remote_heads = [
-                ref.remote_head
-                for ref in src_git_repo.references
-                if isinstance(ref, git.RemoteReference)
-            ]
-            if branch in remote_heads:
-                src_git_repo.git.checkout(branch)
-
-            d2s = Dist2Src(
-                dist_git_path=dist_git_dir,
-                source_git_path=src_git_dir,
-            )
-            d2s.convert(branch, branch)
-
-            # Push the result to source-git.
-
-            # Update moves sg-start tag, we need --tags --force to move it in remote.
-            src_git_repo.git.push("origin", branch, tags=True, force=True)
-            Pushgateway().push_created_update()
-
+            self.update_project(project)
         finally:
             getLogger("dist2src").removeHandler(file_handler)
+
+    def update_project(self, project: PagureProject):
+        # Clone repo from rpms/ and checkout the branch.
+        dist_git_dir = self.workdir / self.fullname
+        shutil.rmtree(dist_git_dir, ignore_errors=True)
+        dist_git_repo = git.Repo.clone_from(
+            f"https://{self.dist_git_host}/{self.fullname}.git", dist_git_dir
+        )
+        dist_git_repo.git.checkout(self.branch)
+
+        # Check if the commit is the one we are expecting.
+        if dist_git_repo.branches[self.branch].commit.hexsha != self.end_commit:
+            logger.warning(
+                f"HEAD of {self.branch} is not matching {self.end_commit}, as expected."
+            )
+
+        # Clone repo from source-git/ using ssh, so it can be pushed later on.
+        src_git_ssh_url = project.get_git_urls()["ssh"]
+        src_git_dir = self.workdir / self.src_git_namespace / self.name
+        shutil.rmtree(src_git_dir, ignore_errors=True)
+        src_git_repo = git.Repo.clone_from(
+            src_git_ssh_url,
+            src_git_dir,
+        )
+
+        # Check-out the source-git branch, if already exists,
+        # so that 'convert' knows that this is an update.
+        remote_heads = [
+            ref.remote_head
+            for ref in src_git_repo.references
+            if isinstance(ref, git.RemoteReference)
+        ]
+        if self.branch in remote_heads:
+            src_git_repo.git.checkout(self.branch)
+
+        d2s = Dist2Src(
+            dist_git_path=dist_git_dir,
+            source_git_path=src_git_dir,
+        )
+        d2s.convert(self.branch, self.branch)
+
+        # Push the result to source-git.
+        # Update moves sg-start tag, we need --tags --force to move it in remote.
+        src_git_repo.git.push("origin", self.branch, tags=True, force=True)
+        Pushgateway().push_created_update()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -35,7 +35,11 @@ def test_event_not_for_dist_git_namespace(caplog):
 
     with caplog.at_level(logging.INFO):
         Processor().process_message(
-            {"repo": {"fullname": "tests/acl", "name": "acl"}, "branch": "c8s"}
+            {
+                "repo": {"fullname": "tests/acl", "name": "acl"},
+                "branch": "c8s",
+                "end_commit": "0a0c838",
+            }
         )
         assert "Ignore update event for tests/acl" in caplog.text
 
@@ -52,7 +56,11 @@ def test_event_not_for_branch(caplog):
 
     with caplog.at_level(logging.INFO):
         Processor().process_message(
-            {"repo": {"fullname": "rpms/acl", "name": "acl"}, "branch": "work"}
+            {
+                "repo": {"fullname": "rpms/acl", "name": "acl"},
+                "branch": "work",
+                "end_commit": "0a0c838",
+            }
         )
         assert "Ignore update event for rpms/acl" in caplog.text
         assert "Branch 'work' is not one of the watched branches" in caplog.text
@@ -79,7 +87,11 @@ def test_no_corresponding_source_git(caplog):
 
     with caplog.at_level(logging.INFO):
         Processor().process_message(
-            {"repo": {"fullname": "rpms/acl", "name": "acl"}, "branch": "c8s"}
+            {
+                "repo": {"fullname": "rpms/acl", "name": "acl"},
+                "branch": "c8s",
+                "end_commit": "0a0c838",
+            }
         )
         assert "Ignore update event for rpms/acl" in caplog.text
 


### PR DESCRIPTION
As was discussed in #124, the `process_message` became bigger and the `try` block is too big as well, so to be able to separate it into another method, I made the variables used in the `try` block attributes of Processor and divided the `process_message`.