### PR TITLE
Use tags unique to the branch for marking the upstream boundary

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,6 +34,7 @@ RUN git config --system user.name "Packit" \
 
 COPY README.md setup.cfg setup.py files/gitconfig files/run_worker.sh /src/
 COPY dist2src /src/dist2src
+RUN ln -s -f /src/pyproject.toml /pyproject.toml
 # setuptools-scm
 COPY .git /src/.git
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ check-in-container:
 		-v $(CURDIR)/packitpatch:/usr/bin/packitpatch:Z \
 		-v $(CURDIR)/macros.packit:/usr/lib/rpm/macros.d/macros.packit:Z \
 		-v $(CURDIR)/tests:/tests:Z \
+		-v $(CURDIR):/src:Z \
 		-u $(shell id -u) \
 		-w / \
 		$(OPTS) \

--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import click
 
 from dist2src.core import Dist2Src
+from dist2src.constants import START_TAG_TEMPLATE
 
 logger = logging.getLogger(__name__)
 
@@ -169,16 +170,17 @@ def copy_all_sources(ctx, origin: str, dest: str):
 
 @cli.command()
 @click.argument("dest", type=click.Path(exists=True, file_okay=False))
+@click.argument("branch", type=click.STRING)
 @log_call
 @click.pass_context
-def add_packit_config(ctx, dest: str):
+def add_packit_config(ctx, dest: str, branch: str):
     """
     Add packit config to the source-git repo and commit it.
     """
     d2s = Dist2Src(
         dist_git_path=None, source_git_path=Path(dest), log_level=ctx.obj[VERBOSE_KEY]
     )
-    d2s.add_packit_config()
+    d2s.add_packit_config(upstream_ref=START_TAG_TEMPLATE.format(branch=branch))
 
 
 @cli.command("convert")

--- a/dist2src/constants.py
+++ b/dist2src/constants.py
@@ -40,7 +40,7 @@ VERY_VERY_HARD_PACKAGES: Iterable[str] = (
 
 # build and test targets
 TARGETS = ["centos-stream-x86_64"]
-START_TAG = "sg-start"
+START_TAG_TEMPLATE = "{branch}-source-git"
 POST_CLONE_HOOK = "post-clone"
 AFTER_PREP_HOOK = "after-prep"
 TEMP_SG_BRANCH = "updates"

--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -151,7 +151,7 @@ class Processor:
         )
 
         # Push the result to source-git.
-        # Update moves sg-start tag, we need --tags --force to move it in remote.
+        # Update moves the upstream ref tag, we need --tags --force to move it in remote.
         src_git_repo.git.push("origin", self.branch, tags=True, force=True)
         Pushgateway().push_created_update()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -24,6 +24,7 @@ def assert_repo_is_not_dirty(repo_path: Union[str, Path]):
     assert not is_dirty
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("package_name,branch", TEST_PROJECTS_WITH_BRANCHES)
 def test_update(tmp_path: Path, package_name, branch):
     """
@@ -78,6 +79,7 @@ def test_update(tmp_path: Path, package_name, branch):
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "package_name,branch", TEST_PROJECTS_WITH_BRANCHES_SINGLE_COMMIT
 )
@@ -148,6 +150,7 @@ def test_update_from_same_commit(tmp_path: Path, package_name, branch):
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "package_name,branch,old_version",
     [
@@ -205,6 +208,7 @@ def test_update_source(tmp_path: Path, package_name, branch, old_version):
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "package",
     (
@@ -253,6 +257,7 @@ def test_update_existing(tmp_path: Path, package):
     assert srpm_path.exists()
 
 
+@pytest.mark.slow
 @pytest.mark.skip(msg="We need packit 0.20")
 def test_update_catch(tmp_path: Path):
     """


### PR DESCRIPTION
This is required, because the tag marking the upstream boundary (the "upstream ref", in Packit terms), is not allowed to be moved in CentOS git in a non-linear fashion. This means, we are not able to reuse the existing tag when creating new branches. Using a tag unique to each branch solves this issue.