### PR TITLE
worker: Abandon updates if dist-git content does not match

### DIFF
--- a/dist2src/worker/monitoring.py
+++ b/dist2src/worker/monitoring.py
@@ -19,6 +19,12 @@ class Pushgateway:
             registry=self.registry,
         )
 
+        self.abandoned_updates = Counter(
+            "abandoned_updates",
+            "Number of updates abandoned",
+            registry=self.registry,
+        )
+
         self.created_updates = Counter(
             "created_updates",
             "Number of created updates",
@@ -84,4 +90,13 @@ class Pushgateway:
         :return:
         """
         self.created_update_task.inc()
+        self.push()
+
+    def push_abandoned_update(self):
+        """
+        Push info about abandoning an update because the dist-git repo
+        has different content than the update event
+        :return:
+        """
+        self.abandoned_updates.inc()
         self.push()

--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -101,8 +101,12 @@ class Processor:
         # Check if the commit is the one we are expecting.
         if dist_git_repo.branches[self.branch].commit.hexsha != self.end_commit:
             logger.warning(
-                f"HEAD of {self.branch} is not matching {self.end_commit}, as expected."
+                f"Abandon updating {self.name}. "
+                f"HEAD of {self.branch!r} is not matching commit "
+                f"{self.end_commit!r} for which this updated was started."
             )
+            Pushgateway().push_abandoned_update()
+            return
 
         # Clone repo from source-git/ using ssh, so it can be pushed later on.
         src_git_ssh_url = project.get_git_urls()["ssh"]


### PR DESCRIPTION
In case the head commit of a dist-git branch found after cloning the
dist-git repo, does not match the commit referenced in the event which
started the update process, abandon the update and register the event in
monitoring.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>