### PR TITLE
Extend 'check-updates' with a 'project' and 'branch' argument

### DIFF
--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -235,11 +235,15 @@ def convert(ctx, origin: str, dest: str):
 
 
 @cli.command()
-def check_updates():
+@click.argument("project", required=False, default=None, type=click.STRING)
+@click.argument("branch", required=False, default=None, type=click.STRING)
+def check_updates(project, branch):
     """
     Check if source-git repositories are up to date.
+
+    Limit the search to PROJECT, and BRANCH, if specified.
     """
-    Updater().check_updates()
+    Updater().check_updates(project, branch)
 
 
 if __name__ == "__main__":

--- a/tests/test_worker_updater.py
+++ b/tests/test_worker_updater.py
@@ -164,6 +164,7 @@ def test_check_updates():
             f"{src_git_svc.api_url}projects",
             params={
                 "namespace": config.src_git_namespace,
+                "pattern": None,
                 "fork": False,
                 "per_page": 100,
                 "owner": None,


### PR DESCRIPTION
Extend the 'check-updates' command with the optional 'project' and
'branch' arguments and limit the search according to those, when they
are specified.

This will allow us to check the update status of individual repositories, instead of scanning the whole namespace every single time.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>