### PR TITLE
Set an ImageStreamTag trigger on the scheduled-update cron job

### DIFF
--- a/deployment/roles/deploy/templates/scheduled-update-cj.yml.j2
+++ b/deployment/roles/deploy/templates/scheduled-update-cj.yml.j2
@@ -5,6 +5,11 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: scheduled-update
+  annotations:
+    # Required so that the image reference bellow is updated, when the ImageStreamTag
+    # gets updated. Can be set on the object with:
+    # oc set triggers cj/scheduled-update --from-image=worker:{{ deployment }} -c scheduled-update
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"worker:{{ deployment }}"},"fieldPath":"spec.jobTemplate.spec.template.spec.containers[?(@.name==\"scheduled-update\")].image"}]'
 spec:
   schedule: "11 22 * * *"
   concurrencyPolicy: "Replace"


### PR DESCRIPTION
Without this, the image reference is not going to be updated when new
images become available, and jobs created will fail pulling the image.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>