### PR TITLE
Don't create Sentry events for every rpmbuild error log line

### DIFF
--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -402,8 +402,14 @@ class Dist2Src:
             try:
                 running_cmd = rpmbuild(*rpmbuild_args)
             except sh.ErrorReturnCode as e:
+                # This might create a tons of error logs.
+                # Create a child logger, so that it's possible to filter
+                # for them, for example in Sentry.
+                rpmbuild_logger = logger.getChild("rpmbuild")
                 for line in e.stderr.splitlines():
-                    logger.error(str(line))
+                    rpmbuild_logger.error(str(line))
+                # Also log the failure using the main logger.
+                logger.error(f"{running_cmd.cmd} failed")
                 raise
 
             self.dist_git.repo.git.checkout(self.relative_specfile_path)

--- a/dist2src/worker/sentry.py
+++ b/dist2src/worker/sentry.py
@@ -20,6 +20,7 @@ def configure_sentry(runner_type: str) -> None:
     # so that we don't have to have sentry sdk installed locally
     from sentry_sdk import init, configure_scope
     from sentry_sdk.integrations.celery import CeleryIntegration
+    from sentry_sdk.integrations.logging import ignore_logger
 
     init(
         dsn=getenv("SENTRY_DSN"),
@@ -28,3 +29,6 @@ def configure_sentry(runner_type: str) -> None:
     )
     with configure_scope() as scope:
         scope.set_tag("runner-type", runner_type)
+
+    # Ignore the error logs from the 'rpmbuild' command
+    ignore_logger("dist2src.core.rpmbuild")


### PR DESCRIPTION
'tar' creates an error log line for every file from the archive when
volumes are full. There is no point in creating an event for every one
of them in Sentry. It also eats up the event-budget, which can lead to
increased costs.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>