### PR TITLE
git: Disable detecting renames

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -3,3 +3,5 @@
     email = user-cont-team+packit-service@redhat.com
 [push]
     default = current
+[merge]
+    renames = false


### PR DESCRIPTION
Updating repositories with a large number of files might fail when file
renames are detected by Git. This happens when merge is involved in some
way, for example during cherry-picks.

Tried increasing `merge.renameLimit` to `999999`, but this did not
reliably fix the issues. Disabling rename detection did.

If my understanding is correct this will cause renames to show up as
separate `rm` and `add` operations in the Git history. This should be
fine as the usefulness of the source-git history is already limited.

Fixes #157.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>