### PR TITLE
Increase the memory limit for the scheduled update CronJob

### DIFF
--- a/deployment/roles/deploy/templates/scheduled-update-cj.yml.j2
+++ b/deployment/roles/deploy/templates/scheduled-update-cj.yml.j2
@@ -43,6 +43,6 @@ spec:
                     name: git-tokens
               resources:
                 limits:
-                  memory: "80Mi"
+                  memory: "160Mi"
                   cpu: "100m"
           restartPolicy: Never


### PR DESCRIPTION
Pods got quite often OOMKilled, this should help with that.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>