### PR TITLE
Install ghc-rpm-macros used in pandoc's %prep section

### DIFF
--- a/files/install-deps.yml
+++ b/files/install-deps.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install dependencies for dist2src.
+- name: Install dependencies for dist2src
   hosts: all
   tasks:
     - name: Install as many (setup.cfg) deps from RPM as possible
@@ -45,6 +45,8 @@
           - xmlto
           # kernel needs pathfix.py
           - python3-devel
+          # pandoc
+          - ghc-rpm-macros
         state: latest
     - name: Install gtk-doc
       shell: dnf --enablerepo=powertools --setopt=powertools.module_hotfixes=true install -y javapackages-local gtk-doc


### PR DESCRIPTION
Signed-off-by: Hunor Csomortáni <csomh@redhat.com>