### PR TITLE
Collect metric when dist2src finished checking source-git updates

### DIFF
--- a/dist2src/worker/monitoring.py
+++ b/dist2src/worker/monitoring.py
@@ -43,6 +43,12 @@ class Pushgateway:
             registry=self.registry,
         )
 
+        self.dist2src_finished_checking_updates = Counter(
+            "dist2src_finished_checking_updates",
+            "Number of times check_updates finished checking all source-git repos.",
+            registry=self.registry,
+        )
+
     def push(self):
         """
         Push collected metrics to Pushgateway
@@ -99,4 +105,13 @@ class Pushgateway:
         :return:
         """
         self.abandoned_updates.inc()
+        self.push()
+
+    def push_dist2src_finished_checking_updates(self):
+        """
+        Increment the counter and push it when dist2src finished checking
+        updates for all source-git repositories in the namespace
+        :return:
+        """
+        self.dist2src_finished_checking_updates.inc()
         self.push()

--- a/dist2src/worker/updater.py
+++ b/dist2src/worker/updater.py
@@ -83,6 +83,7 @@ class Updater:
                         f"Failed checking project {src_git_project['name']!r}"
                     )
                     continue
+        Pushgateway().push_dist2src_finished_checking_updates()
 
     def _check_project(self, project: str, branch: Optional[str] = None):
         logger.debug(f"Checking project {project!r}...")

--- a/tests/test_worker_updater.py
+++ b/tests/test_worker_updater.py
@@ -215,5 +215,9 @@ def test_check_updates():
     ).once()
     # source-git repos without a dist-git counterpart are monitored
     flexmock(Pushgateway).should_receive("push_found_missing_dist_git_repo").once()
+    # finishing the check-update process is monitored
+    flexmock(Pushgateway).should_receive(
+        "push_dist2src_finished_checking_updates"
+    ).once()
 
     Updater(configuration=config).check_updates()


### PR DESCRIPTION
Sentry does notify us about errors, but those errors sometimes break the
loop of checking for source-git updates and we have no easy way to tell
that this happened.

Collect a metric when the loop ends, so that we can set up an alert if
the counter misses a day.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>