### PR TITLE
git: use safecrlf = true

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -6,4 +6,5 @@
 [merge]
     renames = false
 [core]
-    autocrlf = input
+    safecrlf = true
+    # autocrlf = input


### PR DESCRIPTION
from git-config:

    If true, makes Git check if converting CRLF is reversible when
    end-of-line conversion is active. Git will verify if a command
    modifies a file in the work tree either directly or indirectly. For
    example, committing a file followed by checking out the same file
    should yield the original file in the work tree. If this is not the
    case for the current setting of core.autocrlf, Git will reject the
    file. The variable can be set to "warn", in which case Git will only
    warn about an irreversible conversion but continue the operation.
  
    CRLF conversion bears a slight chance of corrupting data. When it is
    enabled, Git will convert CRLF to LF during commit and LF to CRLF
    during checkout. A file that contains a mixture of LF and CRLF before
    the commit cannot be recreated by Git. For text files this is the
    right thing to do: it corrects line endings such that we have only LF
    line endings in the repository. But for binary files that are
    accidentally classified as text the conversion can corrupt data.

this has worked for me when converting gnome-shell-extensions and bind
from scratch

Fixes #167
