### PR TITLE
Revert "gitconfig: Set core.autocrlf to input"

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -5,5 +5,3 @@
     default = current
 [merge]
     renames = false
-[core]
-    autocrlf = input


### PR DESCRIPTION
It seems it will actually brake some git operations and it's not needed.

Though I'm still confused, how this should work.

Fixes #167.

This reverts commit 4bb8900ef06324ebbdb3e662af693be950e8421b.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>