### PR TITLE
Set repo and branch tags in the current Sentry context

### DIFF
--- a/dist2src/worker/decorators.py
+++ b/dist2src/worker/decorators.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 from logging import getLogger
 
 logger = getLogger(__name__)
@@ -13,16 +14,36 @@ class only_once(object):
 
     def __init__(self, func):
         self.func = func
-        self.configured = False
+        self.__name__ = func.__name__
+        self.already_called = False
 
     def __call__(self, *args, **kwargs):
-        if self.configured:
+        if self.already_called:
             logger.debug(f"Function {self.func.__name__} already called. Skipping.")
             return
 
-        self.configured = True
+        self.already_called = True
         logger.debug(
             f"Function {self.func.__name__} called for the first time with "
             f"args: {args} and kwargs: {kwargs}"
         )
         return self.func(*args, **kwargs)
+
+
+class if_sentry_is_enabled:
+    """Run the function only if the env vars to configure Sentry are set."""
+
+    def __init__(self, func):
+        self.func = func
+        self.__name__ = func.__name__
+        self.configured = getenv("SENTRY_DSN") or getenv("DEPLOYMENT")
+        if not self.configured:
+            logger.warning("$SENTRY_DSN or $DEPLOYMENT not set")
+
+    def __call__(self, *args, **kwargs):
+        if self.configured:
+            return self.func(*args, **kwargs)
+        else:
+            logger.debug(
+                f"Sentry is not configured, don't call {self.func.__name__!r}."
+            )

--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -15,6 +15,7 @@ from dist2src.worker.monitoring import Pushgateway
 from dist2src.worker.config import Configuration
 from dist2src.worker import logging as worker_logging
 from dist2src.worker import singular_fork
+from dist2src.worker import sentry
 
 logger = getLogger(__name__)
 
@@ -37,6 +38,8 @@ class Processor:
         self.end_commit = event["end_commit"]
         self.dist_git_dir = self.cfg.workdir / self.cfg.dist_git_namespace / self.name
         self.src_git_dir = self.cfg.workdir / self.cfg.src_git_namespace / self.name
+        sentry.set_tag("repo", self.fullname)
+        sentry.set_tag("branch", self.branch)
 
         logger.info(f"Processing message with {event}")
         # Should this package and branch be ignored?

--- a/dist2src/worker/sentry.py
+++ b/dist2src/worker/sentry.py
@@ -4,18 +4,15 @@
 from logging import getLogger
 from os import getenv
 
-from dist2src.worker.decorators import only_once
+from dist2src.worker.decorators import only_once, if_sentry_is_enabled
 
 logger = getLogger(__name__)
 
 
 @only_once
+@if_sentry_is_enabled
 def configure_sentry(runner_type: str) -> None:
     logger.debug("Setting up Sentry")
-
-    if not getenv("SENTRY_DSN") or not getenv("DEPLOYMENT"):
-        logger.warning("$SENTRY_DSN or $DEPLOYMENT not set")
-        return
 
     # so that we don't have to have sentry sdk installed locally
     from sentry_sdk import init, configure_scope
@@ -32,3 +29,11 @@ def configure_sentry(runner_type: str) -> None:
 
     # Ignore the error logs from the 'rpmbuild' command
     ignore_logger("dist2src.core.rpmbuild")
+
+
+@if_sentry_is_enabled
+def set_tag(key: str, value: str) -> None:
+    # so that we don't have to have sentry sdk installed locally
+    import sentry_sdk
+
+    sentry_sdk.set_tag(key, value)


### PR DESCRIPTION
This way events should become easier to be identified in the Sentry web
UI.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>