### PR TITLE
worker: Don't retry on 404

### DIFF
--- a/dist2src/worker/config.py
+++ b/dist2src/worker/config.py
@@ -27,7 +27,6 @@ class Configuration:
         self._retries = Retry(
             total=5,
             backoff_factor=1,
-            status_forcelist=Retry.RETRY_AFTER_STATUS_CODES.union([404]),
         )
 
     @property


### PR DESCRIPTION
Retrying on 404 status codes was introduced, b/c git.centos.org often
returns 404 for `api/0/-/whoami` endpoints for an unknown reason.

But retrying on 404 for all endpoints is problematic. It causes for
example `project.exists()` calls to err with RetryError, b/c under the
hood the value returned by `exists()` relies on the return code.

Do not include 404 in the list of status codes to be retried anymore in
order to make `project.exists()` work again. Revisit the `whoami` issue
at a later date.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>