### PR TITLE
Ignore updating 'osinfo-db'

### DIFF
--- a/dist2src/constants.py
+++ b/dist2src/constants.py
@@ -145,6 +145,8 @@ IGNORED_PACKAGES: Iterable[Tuple[str, str]] = [
     ("mozjs60", "c8"),
     ("nss", "c8"),
     ("nss", "c8s"),
+    # https://github.com/packit/dist-git-to-source-git/issues/164
+    ("osinfo-db", "c8s"),
     ("pcp", "c8"),
     ("pcp", "c8s"),
     ("pcs", "c8"),


### PR DESCRIPTION
The package is missing the `%prep` section which is currently not
handled. See #164.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>