### PR TITLE
Specify username when getting Pagure projects

### DIFF
--- a/dist2src/worker/processor.py
+++ b/dist2src/worker/processor.py
@@ -72,7 +72,10 @@ class Processor:
 
         # Does this repository have a source-git equivalent?
         src_git_project = self.cfg.src_git_svc.get_project(
-            namespace=singular_fork(self.cfg.src_git_namespace), repo=self.name
+            namespace=singular_fork(self.cfg.src_git_namespace),
+            repo=self.name,
+            # Specify username in order to disable superfluous whoami API calls.
+            username="packit",
         )
         if not src_git_project.exists():
             logger.info(

--- a/dist2src/worker/updater.py
+++ b/dist2src/worker/updater.py
@@ -90,6 +90,8 @@ class Updater:
         dist_git_project = self.cfg.dist_git_svc.get_project(
             namespace=singular_fork(self.cfg.dist_git_namespace),
             repo=project,
+            # Specify username in order to disable superfluous whoami API calls.
+            username="packit",
         )
         if not dist_git_project.exists():
             logger.warning(
@@ -131,7 +133,10 @@ class Updater:
 
         # Get tags from source-git
         src_git_project = self.cfg.src_git_svc.get_project(
-            namespace=singular_fork(self.cfg.src_git_namespace), repo=project
+            namespace=singular_fork(self.cfg.src_git_namespace),
+            repo=project,
+            # Specify username in order to disable superfluous whoami API calls.
+            username="packit",
         )
         src_git_tags = set(tag.name for tag in src_git_project.get_tags())
         logger.debug(f"Current tags in source-git: {src_git_tags}")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -84,7 +84,7 @@ def test_no_corresponding_source_git(caplog):
     (
         flexmock(PagureService)
         .should_receive("get_project")
-        .with_args(namespace="source-git", repo="acl")
+        .with_args(namespace="source-git", repo="acl", username="packit")
         .and_return(project)
     )
     project.should_receive("exists").and_return(False)
@@ -117,7 +117,7 @@ def test_already_up_to_date(caplog):
     (
         flexmock(PagureService)
         .should_receive("get_project")
-        .with_args(namespace="source-git", repo="acl")
+        .with_args(namespace="source-git", repo="acl", username="packit")
         .and_return(src_git_project)
     )
     src_git_project.should_receive("exists").and_return(True)
@@ -150,7 +150,7 @@ def test_conversion(caplog):
     (
         flexmock(PagureService)
         .should_receive("get_project")
-        .with_args(namespace="source-git", repo="acl")
+        .with_args(namespace="source-git", repo="acl", username="packit")
         .and_return(src_git_project)
     )
     src_git_project.should_receive("exists").and_return(True)

--- a/tests/test_worker_updater.py
+++ b/tests/test_worker_updater.py
@@ -53,7 +53,7 @@ def test_get_out_of_date_branches():
     src_git_project = flexmock()
     (
         src_git_svc.should_receive("get_project")
-        .with_args(namespace=config.src_git_namespace, repo="rsync")
+        .with_args(namespace=config.src_git_namespace, repo="rsync", username="packit")
         .and_return(src_git_project)
         .once()
     )
@@ -192,7 +192,9 @@ def test_check_updates():
     for project in ["acl", "rsync", "kernel", "systemd"]:
         (
             dist_git_svc.should_receive("get_project")
-            .with_args(namespace=config.dist_git_namespace, repo=project)
+            .with_args(
+                namespace=config.dist_git_namespace, repo=project, username="packit"
+            )
             .and_return(dist_git_projects[project])
         )
         (


### PR DESCRIPTION
PagureService.get_project() [calls] PagureService.get_username() in case
a username keyword argument is not specified. But the way projects are
used in dist2src context, these calls are superfluous—projects don't
need an associated username—and they often fail. Specify a username in
order to avoid them.

[calls]: https://github.com/packit/ogr/blob/c7d19dce60462f484223d9ace2d9c0eaee8afa59/ogr/services/pagure/service.py#L100

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>