### PR TITLE
populate "sources" in packit.yaml

### DIFF
--- a/dist2src/cli.py
+++ b/dist2src/cli.py
@@ -196,7 +196,9 @@ def add_packit_config(ctx, dest: str, branch: str):
     d2s = Dist2Src(
         dist_git_path=None, source_git_path=Path(dest), log_level=ctx.obj[VERBOSE_KEY]
     )
-    d2s.add_packit_config(upstream_ref=START_TAG_TEMPLATE.format(branch=branch))
+    d2s.add_packit_config(
+        upstream_ref=START_TAG_TEMPLATE.format(branch=branch), lookaside_branch=branch
+    )
 
 
 @cli.command("convert")

--- a/files/install-deps.yml
+++ b/files/install-deps.yml
@@ -11,9 +11,15 @@
           - python3-redis
           - python3-lazy-object-proxy
           - python3-timeout-decorator
-          - packit
         state: latest
         enablerepo: powertools
+    - name: Install as many (setup.cfg) deps from RPM as possible
+      dnf:
+        name:
+          # drop this task once packit 0.27 hits stable
+          - packit
+        state: latest
+        enablerepo: powertools,epel-testing
     - name: Install tools required by %prep section of some packages
       dnf:
         name:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     GitPython
     packitos
     rebasehelper
+    requests
     sh
     timeout-decorator
     # worker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,12 @@ TEST_PROJECTS_WITH_BRANCHES = [
     # %autosetup -S git_am + needs https://koji.mbox.centos.org/koji/taginfo?tagID=342
     ("pacemaker", "c8s"),
     ("systemd", "c8s"),  # -S git_am
-    ("kernel", "c8s"),  # !!!
+    # ("kernel", "c8s"),  # horribly slow, a giant repo
     # (
     #    "qemu-kvm",
     #    "c8s-stream-rhel",
     # ),  # %setup -q -n qemu-%{version} + %autopatch -p1
+    #     # probably even slower than kernel
     # (
     #    "libvirt",
     #    "c8s-stream-rhel",

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,14 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from dist2src.core import GitRepo
+
+
+def test_is_file_tracked(tmp_path: Path):
+    g = GitRepo(tmp_path, create=True)
+    (g.repo_path / "file").write_text("asd")
+    g.stage("file")
+    g.commit("stuff")
+    assert g.is_file_tracked("file")
+    assert not g.is_file_tracked("file2")


### PR DESCRIPTION
Fixes #179

* [x] wait for packit 0.27:
    ```
    We need this for the current PR but it fails to be installed in Zuul - it times out on this task
    let's make the tests fail then and wait for an actual packit release
    ```
