### PR TITLE
Multiple changes to create current c8s repos on GitLab

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,12 +26,6 @@ RUN $package_manager install epel-release \
     && ansible-playbook -vv -c local -i localhost, /src/install-deps-worker.yml \
     && $package_manager clean all
 
-# https://stackoverflow.com/questions/6842687/the-remote-end-hung-up-unexpectedly-while-git-cloning
-# we are unable to clone kernel, hence the postBuffer thingy
-RUN git config --system user.name "Packit" \
-    && git config --system user.email "packit" \
-    && git config --system http.postBuffer 1048576000
-
 COPY README.md setup.cfg setup.py files/gitconfig files/run_worker.sh /src/
 COPY dist2src /src/dist2src
 RUN ln -s -f /src/pyproject.toml /pyproject.toml

--- a/dist2src/constants.py
+++ b/dist2src/constants.py
@@ -93,7 +93,7 @@ VERY_VERY_HARD_PACKAGES: Iterable[str] = (
 )
 
 # build and test targets
-TARGETS = ["centos-stream-x86_64"]
+TARGETS = ["centos-stream-8-x86_64"]
 START_TAG_TEMPLATE = "{branch}-source-git"
 POST_CLONE_HOOK = "post-clone"
 AFTER_PREP_HOOK = "after-prep"

--- a/dist2src/core.py
+++ b/dist2src/core.py
@@ -763,7 +763,7 @@ class Dist2Src:
         for patches which are applied in conditions
         and the condition is evaluated to false during conversion,
         we cannot create a SRPM because rpmbuild wants the patch files present
-        and obviously packit dones't know how to create those
+        and obviously packit doesn't know how to create those
 
         this method copies all patch files which are defined and are not in the patch metadata
         """

--- a/files/gitconfig
+++ b/files/gitconfig
@@ -1,7 +1,11 @@
 [user]
-    name = Packit Service
-    email = user-cont-team+packit-service@redhat.com
+    name = Packit Bot
+    email = centos-stream-packit@redhat.com
 [push]
     default = current
 [merge]
     renames = false
+[http]
+    # https://stackoverflow.com/questions/6842687/the-remote-end-hung-up-unexpectedly-while-git-cloning
+    # we are unable to clone kernel, hence the postBuffer thingy
+    postBuffer = 1048576000

--- a/files/install-deps.yml
+++ b/files/install-deps.yml
@@ -38,6 +38,8 @@
           - xmlto
           # kernel needs pathfix.py
           - python3-devel
+          # kernel needs openssl to generate Kconfigs
+          - openssl
           # pandoc
           - ghc-rpm-macros
         state: latest

--- a/tests/test_dist2src.py
+++ b/tests/test_dist2src.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 import requests
+from flexmock import flexmock
+from requests import Response
 
 from dist2src.core import Dist2Src
 from tests.conftest import clone_package, run_dist2src
@@ -218,6 +220,12 @@ def test_packit_yaml_is_correct(tmp_path: Path):
     s.mkdir()
     subprocess.check_call(["git", "init", "."], cwd=s)
     (d / ".pkg.metadata").write_text("123456 SOURCES/archive.tar.gz\n")
+
+    ok_response = Response()
+    ok_response.reason = ""
+    ok_response.status_code = 200
+    flexmock(requests).should_receive("head").and_return(ok_response)
+
     d2s = Dist2Src(dist_git_path=d, source_git_path=s)
     d2s.add_packit_config("U", "c8s", commit=False)
 


### PR DESCRIPTION
```
sources: some are located on a different branch than c8s

e.g. ltrace and wireshark are located on c8 instead of c8s
```

```
remove .gitlab-ci.yml config from upstream sources

so that CentOS Stream GitLab CI is not being triggered.
```

```
make packit.yaml pretty

* no '&' anchors

* no {path: ..., url: ...}, instead we have a block
```

```
packit.yaml: set target to centos-stream-8-x86_64

centos-stream-x86_64 is no longer a thing in mock and soon won't even
work in copr
```

```
git: favour config file over `git config --system`

We were doing two and now it's just one.

Use our official identify for CentOS Stream GitLab.
```