### PR TITLE
build d2s image in host network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 	rm -rf $(DIR)/
 
 build:
-	$(CONTAINER_ENGINE) build -t $(IMAGE_NAME) -f Containerfile .
+	$(CONTAINER_ENGINE) build -t $(IMAGE_NAME) -f Containerfile --network host .
 
 run:
 	$(CONTAINER_ENGINE) run \


### PR DESCRIPTION
to prevent network issues in Zuul caused by "emulated" container
networking misbehaving in Zuul's VMs