### PR TITLE
Mirror nginx and prom-aggregation-gateway on Quay.io

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,4 +1,4 @@
-## Deployment for dist2src-update service
+# Deployment for dist2src-update service
 
 See [roles/deploy/README.md](roles/deploy/README.md) for instructions, short version:
 
@@ -7,3 +7,18 @@ See [roles/deploy/README.md](roles/deploy/README.md) for instructions, short ver
 - run `DEPLOYMENT={myenvironment} make deploy`
 
 Where `{myenvironment}` might be for example 'prod' or 'local'.
+
+# Container images
+
+All container images are pulled from [quay.io/packit](https://quay.io/organization/packit).
+
+The following images are synced from Docker Hub to the namespace above, using
+`skopeo`. Make sure to `podman login` to quay.io first.
+
+[weaveworks/prom-aggregation-gateway](https://hub.docker.com/r/weaveworks/prom-aggregation-gateway):
+
+    skopeo sync --src docker --dest docker docker.io/weaveworks/prom-aggregation-gateway:latest quay.io/packit
+
+[nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged):
+
+    skopeo sync --src docker --dest docker docker.io/nginxinc/nginx-unprivileged:latest quay.io/packit

--- a/deployment/roles/deploy/files/nginx-dc.yml
+++ b/deployment/roles/deploy/files/nginx-dc.yml
@@ -23,7 +23,7 @@ spec:
             name: nginx
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: quay.io/packit/nginx-unprivileged
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/deployment/roles/deploy/files/pushgateway-dc.yml
+++ b/deployment/roles/deploy/files/pushgateway-dc.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: pushgateway
-          image: weaveworks/prom-aggregation-gateway
+          image: quay.io/packit/prom-aggregation-gateway
           args: ["--listen=:9091"]
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
The deployment keeps breaking b/c of pull rate-limits on Docker.io. Set
up a mirror for these two images on Quay.io.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>