### PR TITLE
Make 'make check' more consistent across projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing Guidelines
+
+Please follow common guidelines for our projects [here](https://github.com/packit/contributing).
+
+---
+
+## Please refer to README.md for complete information on running and developing dist-git-to-source-git.
+
+Thank you for your interest!

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-.PHONY: usage convert clean build run check check-in-container deploy check-deployment
+.PHONY: usage convert clean build build-test-image run check check-in-container deploy check-deployment
 
 PACKAGE ?= rpm
 BRANCH ?= c8s
@@ -36,6 +36,9 @@ clean:
 build:
 	$(CONTAINER_ENGINE) build -t $(IMAGE_NAME) -f Containerfile --network host .
 
+# Define this in order to be consistent with other Packit projects
+build-test-image: build
+
 run:
 	$(CONTAINER_ENGINE) run \
 		-ti --rm \
@@ -63,7 +66,6 @@ check-in-container:
 		-v $(CURDIR)/macros.packit:/usr/lib/rpm/macros.d/macros.packit:Z \
 		-v $(CURDIR)/tests:/tests:Z \
 		-v $(CURDIR):/src:Z \
-		-u $(shell id -u) \
 		-w / \
 		$(OPTS) \
 		$(IMAGE_NAME) pytest --color=$(COLOR) --showlocals -vv $(TEST_TARGET)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ history and applies the patches from dist-git.
 In this case though, the starting point is dist-git itself, so a few things
 need to be done differently.
 
-_Note:_ things bellow were done on git.centos.org/rpms/rpm.
+_Note:_ things below were done on git.centos.org/rpms/rpm.
 
 ## Intermezzo: what should happen to all the patches?
 
@@ -121,14 +121,14 @@ sub-directory and the resulting source-git repo is going to be stored in
 
 ## Tests
 
-In `tests` test suite, you can find functional tests which convert
+In the `tests` test suite, you can find functional tests which convert
 real dist-git packages.
-They can be run inside container (`make build` and
+
+They can be run in a container (`make build-test-image` and
 `make check-in-container`) or on localhost (`make check`).
 
-- You can override container engine of your choice
-  with env var `CONTAINER_ENGINE`.
-- When running locally, have mock installed and set up -- last step of
+- You can override the container engine via the env var `CONTAINER_ENGINE`.
+- When running locally, have mock installed and set up -- the last step of
   the testing is to build the generated SRPM from a source-git repo
   using `mock --rebuild -r centos-stream-x86_64`).
 


### PR DESCRIPTION
Makefile:
Add 'build-test-image' target, (possibly) distinct from
'build' target.

README.md:
Add mention of 'make build-test-image'

Add CONTRIBUTING.md stub with pointer back to README.md.

Signed-off-by: Ben Crocker <bcrocker@redhat.com>