### PR TITLE
Disable updating edk2:c8s

### DIFF
--- a/dist2src/constants.py
+++ b/dist2src/constants.py
@@ -121,6 +121,8 @@ IGNORED_PACKAGES: Iterable[Tuple[str, str]] = [
     ("cockpit", "c8s"),
     ("cockpit-appstream", "c8s"),
     ("docbook-dtds", "c8"),
+    # git used in %prep, c8s branch was deleted from src/edk2
+    ("edk2", "c8s"),
     ("gcc", "c8"),
     ("gcc", "c8s"),
     ("google-noto-cjk-fonts", "c8s"),


### PR DESCRIPTION
The c8s branch was deleted from redhat/centos-stream/rpms/edk2. Also the
%prep section is weird, and this cause updates to fail.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>