### PR TITLE
Don't set LANG env. var. in the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,8 +6,7 @@ ARG package_manager
 FROM $base_image
 
 # GIT_EDITOR: git cherry-pick --continue prompts editor, this is the only way to make it non-interactive
-ENV LANG=en_US.UTF-8 \
-    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
     HOME=/home/packit \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def run_packit(*args, working_dir=None, **kwargs):
 
 def clone_package_rpms(
     package_name: str,
-    dist_git_path: str,
+    dist_git_path: Path,
     branch: str = "c8s",
 ):
     """
@@ -101,14 +101,14 @@ def clone_package_rpms(
             "-b",
             branch,
             f"https://git.centos.org/rpms/{package_name}.git",
-            dist_git_path,
+            str(dist_git_path),
         ]
     )
 
 
 def clone_package_src(
     package_name: str,
-    src_git_path: str,
+    src_git_path: Path,
     branch: str = "c8s",
 ):
     """
@@ -121,6 +121,6 @@ def clone_package_src(
             "-b",
             branch,
             f"https://gitlab.com/redhat/centos-stream/src/{package_name}.git",
-            src_git_path,
+            str(src_git_path),
         ]
     )

--- a/tests/test_dist2src.py
+++ b/tests/test_dist2src.py
@@ -147,7 +147,7 @@ def test_no_backup(tmp_path: Path):
     d = tmp_path / "d"
     d.mkdir()
     dist_git_path = d / package_name
-    clone_package_rpms(package_name, str(dist_git_path), branch="c8")
+    clone_package_rpms(package_name, dist_git_path, branch="c8")
     b = dist_git_path / "BUILD" / "hyperv-daemons-0"
     run_dist2src(["-v", "run-prep", str(dist_git_path)], working_dir=dist_git_path)
     assert b.is_dir()
@@ -169,7 +169,7 @@ def test_get_lookaside_sources(tmp_path: Path, package, branch):
     s.mkdir()
     dist_git_path = d / package
     source_git_path = s / package
-    clone_package_rpms(package, str(dist_git_path), branch=branch)
+    clone_package_rpms(package, dist_git_path, branch=branch)
 
     d2s = Dist2Src(dist_git_path=dist_git_path, source_git_path=source_git_path)
     sources = d2s.get_lookaside_sources(branch)
@@ -191,7 +191,7 @@ def test_gitlab_ci_config_removed(tmp_path: Path):
     s.mkdir()
     dist_git_path = d / package
     source_git_path = s / package
-    clone_package_rpms(package, str(dist_git_path), branch="c8s")
+    clone_package_rpms(package, dist_git_path, branch="c8s")
     gitlab_config_name = ".gitlab-ci.yml"
 
     d2s = Dist2Src(dist_git_path=dist_git_path, source_git_path=source_git_path)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -38,7 +38,7 @@ def test_update(tmp_path: Path, package_name, branch):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
 
-    clone_package_rpms(package_name, str(dist_git_path), branch=branch)
+    clone_package_rpms(package_name, dist_git_path, branch=branch)
     subprocess.check_call(
         ["git", "reset", "--hard", "HEAD~1"],
         cwd=dist_git_path,
@@ -95,7 +95,7 @@ def test_update_from_same_commit(tmp_path: Path, package_name, branch):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
 
-    clone_package_rpms(package_name, str(dist_git_path), branch=branch)
+    clone_package_rpms(package_name, dist_git_path, branch=branch)
 
     run_dist2src(
         ["-vvv", "convert", f"{dist_git_path}:{branch}", f"{sg_path}:{branch}"]
@@ -161,7 +161,7 @@ def test_update_source(tmp_path: Path, package_name, branch, old_version):
     dist_git_path.mkdir(parents=True)
     sg_path.mkdir(parents=True)
 
-    clone_package_rpms(package_name, str(dist_git_path), branch=branch)
+    clone_package_rpms(package_name, dist_git_path, branch=branch)
     subprocess.check_call(
         ["git", "reset", "--hard", old_version],
         cwd=dist_git_path,
@@ -220,8 +220,8 @@ def test_update_existing(tmp_path: Path, package):
     dg_branch = "c8s"
     source_git_path = tmp_path / "s" / package
     sg_branch = "c8s"
-    clone_package_rpms(package, str(dist_git_path), branch=dg_branch)
-    clone_package_src(package, str(source_git_path), branch=sg_branch)
+    clone_package_rpms(package, dist_git_path, branch=dg_branch)
+    clone_package_src(package, source_git_path, branch=sg_branch)
     run_dist2src(
         [
             "-vvv",
@@ -250,10 +250,10 @@ def test_update_catch(tmp_path: Path):
     dg_branch = "c8"
     source_git_path = tmp_path / "s" / package
     sg_branch = "c8"
-    clone_package_rpms(package, str(dist_git_path), branch=dg_branch)
+    clone_package_rpms(package, dist_git_path, branch=dg_branch)
     clone_package_src(
         package,
-        str(source_git_path),
+        source_git_path,
         branch=sg_branch,
     )
     run_dist2src(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -64,8 +64,8 @@ def test_update(tmp_path: Path, package_name, branch):
         ["--debug", "srpm", "."],
         working_dir=sg_path,  # _srcrpmdir rpm macro is set to /, let's CWD then
     )
-    srpm_path = next(sg_path.glob("*.src.rpm"))
-    assert srpm_path.exists()
+    srpms = list(sg_path.glob("*.src.rpm"))
+    assert srpms, "No src.rpm found"
     if MOCK_BUILD:
         subprocess.check_call(
             [
@@ -73,7 +73,7 @@ def test_update(tmp_path: Path, package_name, branch):
                 "--rebuild",
                 "-r",
                 "centos-stream-x86_64",
-                srpm_path,
+                srpms[0],
             ]
         )
 
@@ -118,8 +118,8 @@ def test_update_from_same_commit(tmp_path: Path, package_name, branch):
         ["--debug", "srpm", "."],
         working_dir=sg_path,  # _srcrpmdir rpm macro is set to /, let's CWD then
     )
-    srpm_path = next(sg_path.glob("*.src.rpm"))
-    assert srpm_path.exists()
+    srpms = list(sg_path.glob("*.src.rpm"))
+    assert srpms, "No src.rpm found"
 
     # Check that patch commits are same
     assert len(first_round_commits) == len(second_round_commits)
@@ -141,7 +141,7 @@ def test_update_from_same_commit(tmp_path: Path, package_name, branch):
                 "--rebuild",
                 "-r",
                 "centos-stream-x86_64",
-                srpm_path,
+                srpms[0],
             ]
         )
 
@@ -187,8 +187,8 @@ def test_update_source(tmp_path: Path, package_name, branch, old_version):
         ["--debug", "srpm", "."],
         working_dir=sg_path,  # _srcrpmdir rpm macro is set to /, let's CWD then
     )
-    srpm_path = next(sg_path.glob("*.src.rpm"))
-    assert srpm_path.exists()
+    srpms = list(sg_path.glob("*.src.rpm"))
+    assert srpms, "No src.rpm found"
     if MOCK_BUILD:
         subprocess.check_call(
             [
@@ -196,7 +196,7 @@ def test_update_source(tmp_path: Path, package_name, branch, old_version):
                 "--rebuild",
                 "-r",
                 "centos-stream-x86_64",
-                srpm_path,
+                srpms[0],
             ]
         )
 
@@ -235,8 +235,8 @@ def test_update_existing(tmp_path: Path, package):
         ["--debug", "srpm", "."],
         working_dir=source_git_path,
     )
-    srpm_path = next(source_git_path.glob("*.src.rpm"))
-    assert srpm_path.exists()
+    srpms = list(source_git_path.glob("*.src.rpm"))
+    assert srpms, "No src.rpm found"
 
 
 @pytest.mark.slow
@@ -269,8 +269,9 @@ def test_update_catch(tmp_path: Path):
         ["--debug", "srpm", "."],
         working_dir=source_git_path,
     )
-    srpm_path = next(source_git_path.glob("*.src.rpm"))
-    assert srpm_path.exists()
+    srpms = list(source_git_path.glob("*.src.rpm"))
+    assert srpms, "No src.rpm found"
+
     git_log_out = subprocess.check_output(
         ["git", "log", "--pretty=format:%s", "origin/c8.."], cwd=source_git_path
     ).decode()


### PR DESCRIPTION
Previously, creating of pacemaker srpm [failed](https://softwarefactory-project.io/zuul/t/packit-service/build/e1f2c344fae843aab7c42ff23f391bf4) with:

```    
      File "/usr/lib/python3.6/site-packages/packit/specfile.py", line 48, in update_changelog_in_spec
        self.update_changelog(changelog_entry)
      File "/usr/lib/python3.6/site-packages/rebasehelper/specfile.py", line 109, in wrapper
        func(spec, *args, **kwargs)
      File "/usr/lib/python3.6/site-packages/rebasehelper/specfile.py", line 1059, in update_changelog
        new_entry = self.get_new_log(changelog_entry)
      File "/usr/lib/python3.6/site-packages/rebasehelper/specfile.py", line 1088, in get_new_log
        locale.setlocale(locale.LC_TIME, old_locale)
      File "/usr/lib64/python3.6/locale.py", line 598, in setlocale
        return _setlocale(category, locale)
    locale.Error: unsupported locale setting
```

The other tests are still expected to [fail](https://softwarefactory-project.io/zuul/t/packit-service/build/e1f2c344fae843aab7c42ff23f391bf4) until packit/packit#1372 is released.
