### PR TITLE
Make package installation OS independent

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,4 +1,4 @@
-ANSIBLE_PYTHON := /usr/bin/python3
+ANSIBLE_PYTHON ?= $(shell command -v /usr/bin/python3 2> /dev/null || echo /usr/bin/python2)
 AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)
 # "By default, Ansible runs as if --tags all had been specified."
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags

--- a/files/zuul-deploy.yml
+++ b/files/zuul-deploy.yml
@@ -6,10 +6,10 @@
   hosts: all
   tasks:
     - name: Install packages for deployment
-      dnf:
+      package:
         name:
           - ansible
-          - python3-openshift
+          - python-openshift
           - make
       become: true
 


### PR DESCRIPTION
[the oc-cluster-up job now runs on centos7](https://github.com/packit/packit-service-zuul/blob/main/zuul.d/jobs.yaml#L56)