### PR TITLE
Configure the CronJob to use the worker image from Quay.io

### DIFF
--- a/deployment/roles/deploy/templates/scheduled-update-cj.yml.j2
+++ b/deployment/roles/deploy/templates/scheduled-update-cj.yml.j2
@@ -5,11 +5,6 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: scheduled-update
-  annotations:
-    # Required so that the image reference bellow is updated, when the ImageStreamTag
-    # gets updated. Can be set on the object with:
-    # oc set triggers cj/scheduled-update --from-image=worker:{{ deployment }} -c scheduled-update
-    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"worker:{{ deployment }}"},"fieldPath":"spec.jobTemplate.spec.template.spec.containers[?(@.name==\"scheduled-update\")].image"}]'
 spec:
   schedule: "11 22 * * *"
   concurrencyPolicy: "Replace"
@@ -19,14 +14,10 @@ spec:
         metadata:
           labels:
             parent: scheduled-update-cronjob
-          # so that images are first looked up in image streams
-          # configured with: oc set image-lookup cj/scheduled-update
-          annotations:
-            alpha.image.policy.openshift.io/resolve-names: '*'
         spec:
           containers:
             - name: scheduled-update
-              image: worker:{{ deployment }}
+              image: {{ image_worker }}
               command: ["dist2src", "-vvt", "check-updates"]
               env:
                 - name: SENTRY_DSN


### PR DESCRIPTION
Instead of referencing the image from the internal image stream,
directly reference the worker image in Quay.io (or any other registry
it might be stored in). Removing this indirection should ensure the
image to be updated each time the CronJob runs.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>