### PR TITLE
fix image build & update readme

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,6 @@ FROM $base_image
 
 # GIT_EDITOR: git cherry-pick --continue prompts editor, this is the only way to make it non-interactive
 ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
-    ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
     HOME=/home/packit \
     package_manager=${package_manager:-"dnf -y"} \

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ target environment has to be used. This is achieved by running the conversion
 script in a container, built to match the target environment. By default this
 is CentOS 8.
 
-This is currently working only if converting with `convert-with-prep`.
-
 To build the image, run:
 
 ```
@@ -108,7 +106,7 @@ To run the conversion:
 
 ```
 podman run --rm -v $PWD:/workdir:z \
-    dist2src dist2src convert-with-prep rpms/<package>:<branch> source-git/<package>:<branch>
+    dist2src dist2src convert rpms/<package>:<branch> source-git/<package>:<branch>
 ```
 
 Where the current working directory has the package cloned in an `rpms`


### PR DESCRIPTION
ran into these while updating kernel

```
update README: convert-with-prep no longer exists
```

```
latest ansible no longer has debug callback

...which we used to get more convenient and verbose output

Let's just drop it, I assume it was moved to some collection.
```