### PR TITLE
Install setuptools_scm from rpm

### DIFF
--- a/files/install-deps.yml
+++ b/files/install-deps.yml
@@ -15,6 +15,7 @@
           - python3-sh
           - packit
           - nss_wrapper # for openshift so we can have regular packit user in pod
+          - python3-setuptools_scm
         state: latest
         enablerepo: powertools
     - name: Install tools required by %prep section of some packages


### PR DESCRIPTION
The pypi version is not working with the latest python version in c8s.

Should fix this error when executing `make build`:
```
    SyntaxError: future feature annotations is not defined
```